### PR TITLE
Clamp slider index for custom milestones

### DIFF
--- a/src/components/MilestonePicker.tsx
+++ b/src/components/MilestonePicker.tsx
@@ -7,8 +7,10 @@ type Props={
 }
 
 export default function MilestonePicker({amount,setAmount,unit,setUnit}:Props){
-  const idx = SLIDER.indexOf(amount)!==-1 ? SLIDER.indexOf(amount)
-                                          : SLIDER.findIndex(v=>v>amount);
+  let idx = SLIDER.indexOf(amount)!==-1 ? SLIDER.indexOf(amount)
+                                        : SLIDER.findIndex(v=>v>amount);
+  // Clamp index to last slider value if value exceeds defined milestones
+  if (idx === -1) idx = SLIDER.length - 1;
 
   return(
     <section className="card">


### PR DESCRIPTION
## Summary
- guard against invalid slider index when user enters a milestone beyond the configured slider values

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841d8f1a59c832fba3a458bd59c4f4e