### PR TITLE
Remove unused Tailwind build script

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "vite",
     "build": "tsc -b && vite build",
-    "build:css": "tailwindcss build src/index.css -o dist/output.css",
     "lint": "eslint .",
     "preview": "vite preview"
   },


### PR DESCRIPTION
## Summary
- delete obsolete `build:css` script from `package.json`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6841dd003920832f9cc78dcd90da9b65