### PR TITLE
Add vitest and basic unit tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,3 +25,11 @@ To create a production build and preview it locally run:
 npm run build
 npm run preview
 ```
+
+## Testing
+
+Run the unit tests with:
+
+```bash
+npm test
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -27,7 +27,8 @@
         "globals": "^16.0.0",
         "typescript": "~5.7.2",
         "typescript-eslint": "^8.26.1",
-        "vite": "^6.3.1"
+        "vite": "^6.3.1",
+        "vitest": "^1.5.0"
       }
     },
     "node_modules/@ampproject/remapping": {

--- a/package.json
+++ b/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest"
   },
   "dependencies": {
     "@vercel/analytics": "^1.5.0",
@@ -29,6 +30,7 @@
     "globals": "^16.0.0",
     "typescript": "~5.7.2",
     "typescript-eslint": "^8.26.1",
-    "vite": "^6.3.1"
+    "vite": "^6.3.1",
+    "vitest": "^1.5.0"
   }
 }

--- a/src/utils/format.test.ts
+++ b/src/utils/format.test.ts
@@ -1,0 +1,29 @@
+import { describe, it, expect } from 'vitest';
+import { formatNice, formatBig } from './format';
+
+describe('formatNice', () => {
+  it('handles numbers less than a million', () => {
+    expect(formatNice(999)).toBe('999');
+    expect(formatNice(1000)).toBe('1,000');
+  });
+
+  it('formats numbers in millions', () => {
+    expect(formatNice(1_000_000)).toBe('1 million');
+    expect(formatNice(1_500_000)).toBe('1.5 million');
+  });
+
+  it('formats numbers in billions', () => {
+    expect(formatNice(1_000_000_000)).toBe('1 billion');
+    expect(formatNice(1_234_000_000)).toBe('1.2 billion');
+  });
+});
+
+describe('formatBig', () => {
+  it('uses locale string for numbers below 1e12', () => {
+    expect(formatBig(1234)).toBe('1,234');
+  });
+
+  it('uses exponential notation for large numbers', () => {
+    expect(formatBig(1.23e15)).toBe('1.23e15');
+  });
+});


### PR DESCRIPTION
## Summary
- add `vitest` test runner and npm test script
- write coverage for `formatNice` and `formatBig`
- document how to run tests in the README

## Testing
- `npm test --silent` *(fails: vitest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841e0ef261c832f8a41db6bad1b09f7