### PR TITLE
Replace date picker flow with birth wizard

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,6 @@
         "date-fns": "^4.1.0",
         "dayjs": "^1.11.13",
         "react": "^19.0.0",
-        "react-datepicker": "^8.3.0",
         "react-dom": "^19.0.0",
         "react-router-dom": "^7.5.2"
       },
@@ -847,59 +846,6 @@
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
       }
-    },
-    "node_modules/@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "node_modules/@floating-ui/react": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
-      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=17.0.0",
-        "react-dom": ">=17.0.0"
-      }
-    },
-    "node_modules/@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/dom": "^1.0.0"
-      },
-      "peerDependencies": {
-        "react": ">=16.8.0",
-        "react-dom": ">=16.8.0"
-      }
-    },
-    "node_modules/@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg==",
-      "license": "MIT"
     },
     "node_modules/@humanfs/core": {
       "version": "0.19.1",
@@ -2027,15 +1973,6 @@
       },
       "engines": {
         "node": "*"
-      }
-    },
-    "node_modules/clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
       }
     },
     "node_modules/color-convert": {
@@ -3264,21 +3201,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/react-datepicker": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.3.0.tgz",
-      "integrity": "sha512-DhfrIJnTPJTUVRtXU7c7zooug40rD6q+Fc8UTCt19dYEotLpDQgTN98MfocY6Rc4S99oOFFEoxyanOM/TKauuw==",
-      "license": "MIT",
-      "dependencies": {
-        "@floating-ui/react": "^0.27.3",
-        "clsx": "^2.1.1",
-        "date-fns": "^4.1.0"
-      },
-      "peerDependencies": {
-        "react": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc",
-        "react-dom": "^16.9.0 || ^17 || ^18 || ^19 || ^19.0.0-rc"
-      }
-    },
     "node_modules/react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -3566,12 +3488,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew==",
-      "license": "MIT"
     },
     "node_modules/tinybench": {
       "version": "2.9.0",
@@ -5478,46 +5394,6 @@
         "levn": "^0.4.1"
       }
     },
-    "@floating-ui/core": {
-      "version": "1.6.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/core/-/core-1.6.9.tgz",
-      "integrity": "sha512-uMXCuQ3BItDUbAMhIXw7UPXRfAlOAvZzdK9BWpE60MCn+Svt3aLn9jsPTi/WNGlRUu2uI0v5S7JiIUsbsvh3fw==",
-      "requires": {
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "@floating-ui/dom": {
-      "version": "1.6.13",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.13.tgz",
-      "integrity": "sha512-umqzocjDgNRGTuO7Q8CU32dkHkECqI8ZdMZ5Swb6QAM0t5rnlrN3lGo1hdpscRd3WS8T6DKYK4ephgIH9iRh3w==",
-      "requires": {
-        "@floating-ui/core": "^1.6.0",
-        "@floating-ui/utils": "^0.2.9"
-      }
-    },
-    "@floating-ui/react": {
-      "version": "0.27.8",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react/-/react-0.27.8.tgz",
-      "integrity": "sha512-EQJ4Th328y2wyHR3KzOUOoTW2UKjFk53fmyahfwExnFQ8vnsMYqKc+fFPOkeYtj5tcp1DUMiNJ7BFhed7e9ONw==",
-      "requires": {
-        "@floating-ui/react-dom": "^2.1.2",
-        "@floating-ui/utils": "^0.2.9",
-        "tabbable": "^6.0.0"
-      }
-    },
-    "@floating-ui/react-dom": {
-      "version": "2.1.2",
-      "resolved": "https://registry.npmjs.org/@floating-ui/react-dom/-/react-dom-2.1.2.tgz",
-      "integrity": "sha512-06okr5cgPzMNBy+Ycse2A6udMi4bqwW/zgBF/rwjcNqWkyr82Mcg8b0vjX8OJpZFy/FKjJmw6wV7t44kK6kW7A==",
-      "requires": {
-        "@floating-ui/dom": "^1.0.0"
-      }
-    },
-    "@floating-ui/utils": {
-      "version": "0.2.9",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.9.tgz",
-      "integrity": "sha512-MDWhGtE+eHw5JW7lq4qhc5yRLS11ERl1c7Z6Xd0a58DozHES6EnNNwUWbMiG4J9Cgj053Bhk8zvlhFYKVhULwg=="
-    },
     "@humanfs/core": {
       "version": "0.19.1",
       "resolved": "https://registry.npmjs.org/@humanfs/core/-/core-0.19.1.tgz",
@@ -6204,11 +6080,6 @@
       "requires": {
         "get-func-name": "^2.0.2"
       }
-    },
-    "clsx": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/clsx/-/clsx-2.1.1.tgz",
-      "integrity": "sha512-eYm0QWBtUrBWZWG0d386OGAw16Z995PiOVo2B7bjWSbHedGl5e0ZWaq65kOGgUSNesEIDkB9ISbTg/JK9dhCZA=="
     },
     "color-convert": {
       "version": "2.0.1",
@@ -7076,16 +6947,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.1.0.tgz",
       "integrity": "sha512-FS+XFBNvn3GTAWq26joslQgWNoFu08F4kl0J4CgdNKADkdSGXQyTCnKteIAJy96Br6YbpEU1LSzV5dYtjMkMDg=="
     },
-    "react-datepicker": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/react-datepicker/-/react-datepicker-8.3.0.tgz",
-      "integrity": "sha512-DhfrIJnTPJTUVRtXU7c7zooug40rD6q+Fc8UTCt19dYEotLpDQgTN98MfocY6Rc4S99oOFFEoxyanOM/TKauuw==",
-      "requires": {
-        "@floating-ui/react": "^0.27.3",
-        "clsx": "^2.1.1",
-        "date-fns": "^4.1.0"
-      }
-    },
     "react-dom": {
       "version": "19.1.0",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.1.0.tgz",
@@ -7273,11 +7134,6 @@
       "requires": {
         "has-flag": "^4.0.0"
       }
-    },
-    "tabbable": {
-      "version": "6.2.0",
-      "resolved": "https://registry.npmjs.org/tabbable/-/tabbable-6.2.0.tgz",
-      "integrity": "sha512-Cat63mxsVJlzYvN51JmVXIgNoUokrIaT2zLclCXjRd8boZ0004U4KCs/sToJ75C6sdlByWxpYnb5Boif1VSFew=="
     },
     "tinybench": {
       "version": "2.9.0",

--- a/package.json
+++ b/package.json
@@ -16,7 +16,6 @@
     "date-fns": "^4.1.0",
     "dayjs": "^1.11.13",
     "react": "^19.0.0",
-    "react-datepicker": "^8.3.0",
     "react-dom": "^19.0.0",
     "react-router-dom": "^7.5.2"
   },

--- a/src/components/BirthDateWizard.tsx
+++ b/src/components/BirthDateWizard.tsx
@@ -1,0 +1,244 @@
+import { FormEvent, useMemo, useState } from "react";
+
+type BirthDateWizardProps = {
+  initialDate: Date | null;
+  initialTime: string;
+  onCancel: () => void;
+  onComplete: (date: Date, time: string) => void;
+};
+
+const MONTHS = [
+  "Gennaio",
+  "Febbraio",
+  "Marzo",
+  "Aprile",
+  "Maggio",
+  "Giugno",
+  "Luglio",
+  "Agosto",
+  "Settembre",
+  "Ottobre",
+  "Novembre",
+  "Dicembre",
+];
+
+const STEPS = ["year", "month", "day", "hour"] as const;
+
+const CURRENT_YEAR = new Date().getFullYear();
+const MIN_YEAR = 1900;
+
+export default function BirthDateWizard({
+  initialDate,
+  initialTime,
+  onCancel,
+  onComplete,
+}: BirthDateWizardProps) {
+  const [stepIndex, setStepIndex] = useState(0);
+  const [year, setYear] = useState<number | "">(
+    initialDate ? initialDate.getFullYear() : "",
+  );
+  const [month, setMonth] = useState<number | "">(
+    initialDate ? initialDate.getMonth() + 1 : "",
+  );
+  const [day, setDay] = useState<number | "">(
+    initialDate ? initialDate.getDate() : "",
+  );
+  const [hour, setHour] = useState<number | "">(() => {
+    const [rawHour] = initialTime.split(":");
+    const parsed = Number(rawHour);
+    return Number.isFinite(parsed) ? parsed : "";
+  });
+
+  const step = STEPS[stepIndex];
+  const isLastStep = step === "hour";
+  const questionId = `birth-wizard-question-${step}`;
+  const hintId = `birth-wizard-hint-${step}`;
+
+  const daysInMonth = useMemo(() => {
+    if (typeof month !== "number") return 31;
+    const baseYear = typeof year === "number" ? year : CURRENT_YEAR;
+    return new Date(baseYear, month, 0).getDate();
+  }, [month, year]);
+
+  const monthLabel = typeof month === "number" ? MONTHS[month - 1] : "questo mese";
+
+  const isYearValid = typeof year === "number" && year >= MIN_YEAR && year <= CURRENT_YEAR;
+  const isMonthValid = typeof month === "number" && month >= 1 && month <= 12;
+  const isDayValid =
+    typeof day === "number" &&
+    typeof month === "number" &&
+    day >= 1 &&
+    day <= daysInMonth;
+  const isHourValid = typeof hour === "number" && hour >= 0 && hour <= 23;
+
+  const canContinue = (() => {
+    switch (step) {
+      case "year":
+        return isYearValid;
+      case "month":
+        return isMonthValid && isYearValid;
+      case "day":
+        return isDayValid;
+      case "hour":
+        return isHourValid;
+      default:
+        return false;
+    }
+  })();
+
+  const goBack = () => {
+    if (stepIndex === 0) {
+      onCancel();
+    } else {
+      setStepIndex(index => index - 1);
+    }
+  };
+
+  const finish = (finalHour: number) => {
+    if (typeof year !== "number" || typeof month !== "number" || typeof day !== "number") {
+      return;
+    }
+    const result = new Date(year, month - 1, day);
+    result.setHours(0, 0, 0, 0);
+    const safeHour = Number.isFinite(finalHour) ? finalHour : 0;
+    const normalizedHour = Math.min(Math.max(safeHour, 0), 23);
+    const time = `${normalizedHour.toString().padStart(2, "0")}:00`;
+    onComplete(result, time);
+  };
+
+  const handleSubmit = (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    if (!canContinue) return;
+    if (isLastStep && typeof hour === "number") {
+      finish(hour);
+      return;
+    }
+    setStepIndex(index => Math.min(index + 1, STEPS.length - 1));
+  };
+
+  const hintText = (() => {
+    switch (step) {
+      case "year":
+        return `Inserisci un anno tra ${MIN_YEAR} e ${CURRENT_YEAR}.`;
+      case "month":
+        return "Scegli il mese in cui sei nato.";
+      case "day":
+        return `Questo mese ha ${daysInMonth} giorni.`;
+      case "hour":
+        return "Formato 24 ore (0-23).";
+      default:
+        return "";
+    }
+  })();
+
+  return (
+    <div className="birth-wizard" role="dialog" aria-modal="true" aria-labelledby={questionId}>
+      <form className="birth-wizard__panel" aria-describedby={hintId} onSubmit={handleSubmit}>
+        <p className="birth-wizard__step">Passo {stepIndex + 1} di {STEPS.length}</p>
+        <h2 className="birth-wizard__question" id={questionId}>
+          {step === "year" && "In che anno sei nato?"}
+          {step === "month" && "Quale mese?"}
+          {step === "day" && "Quale giorno?"}
+          {step === "hour" && "A che ora?"}
+        </h2>
+
+        <div className="birth-wizard__field">
+          {step === "year" && (
+            <input
+              type="number"
+              inputMode="numeric"
+              min={MIN_YEAR}
+              max={CURRENT_YEAR}
+              value={year}
+              onChange={event => {
+                const value = event.target.value;
+                const parsed = Number(value);
+                setYear(value === "" || Number.isNaN(parsed) ? "" : parsed);
+              }}
+              aria-describedby={hintId}
+              required
+            />
+          )}
+
+          {step === "month" && (
+            <select
+              value={month === "" ? "" : month}
+              onChange={event => {
+                const value = event.target.value;
+                setMonth(value === "" ? "" : Number(value));
+              }}
+              aria-describedby={hintId}
+              required
+            >
+              <option value="" disabled>
+                Seleziona il mese
+              </option>
+              {MONTHS.map((label, index) => (
+                <option key={label} value={index + 1}>
+                  {label}
+                </option>
+              ))}
+            </select>
+          )}
+
+          {step === "day" && (
+            <input
+              type="number"
+              inputMode="numeric"
+              min={1}
+              max={daysInMonth}
+              value={day}
+              onChange={event => {
+                const value = event.target.value;
+                const parsed = Number(value);
+                setDay(value === "" || Number.isNaN(parsed) ? "" : parsed);
+              }}
+              aria-describedby={hintId}
+              required
+            />
+          )}
+
+          {step === "hour" && (
+            <input
+              type="number"
+              inputMode="numeric"
+              min={0}
+              max={23}
+              value={hour}
+              onChange={event => {
+                const value = event.target.value;
+                const parsed = Number(value);
+                setHour(value === "" || Number.isNaN(parsed) ? "" : parsed);
+              }}
+              aria-describedby={hintId}
+              required
+            />
+          )}
+        </div>
+
+        <p className="birth-wizard__hint" id={hintId}>
+          {step === "day" ? `${hintText} (${monthLabel})` : hintText}
+        </p>
+
+        <div className="birth-wizard__actions">
+          <button type="button" className="birth-wizard__secondary" onClick={goBack}>
+            {stepIndex === 0 ? "Chiudi" : "Indietro"}
+          </button>
+          <button type="submit" className="birth-wizard__primary" disabled={!canContinue}>
+            {isLastStep ? "Conferma" : "Avanti"}
+          </button>
+        </div>
+
+        {step === "hour" && (
+          <button
+            type="button"
+            className="birth-wizard__skip"
+            onClick={() => finish(0)}
+          >
+            Non ricordo l'ora (usa 00:00)
+          </button>
+        )}
+      </form>
+    </div>
+  );
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -319,35 +319,163 @@ body::before {
 .age-table .age-val.updated::after { opacity: 1; }
 
 /* -----------------------------------------------------------
-   Date/time picker overrides
+   9. Landing wizard overlay
 ----------------------------------------------------------- */
-.react-datepicker {
-  font-family: system-ui, sans-serif;
-  background: #1d3252;
-  border: 1px solid var(--slate-700);
-  color: var(--text-light);
-  box-shadow: 0 4px 10px rgba(0, 0, 0, 0.6);
+.landing__content {
+  position: relative;
+  transition: filter 0.3s ease;
 }
 
-.react-datepicker__header {
-  background: var(--slate-800);
-  border-bottom: 1px solid var(--slate-700);
+.landing__content--blurred {
+  filter: blur(6px);
+  pointer-events: none;
+  user-select: none;
 }
 
-.react-datepicker__current-month,
-.react-datepicker-time__header,
-.react-datepicker-year-header {
+.landing__cta {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 16px;
+}
+
+.landing__summary {
+  margin: 0;
+  font-size: 0.95rem;
   color: var(--indigo-100);
 }
 
-.react-datepicker__day--selected,
-.react-datepicker__day--keyboard-selected,
-.react-datepicker__time-list-item--selected {
+.birth-wizard {
+  position: fixed;
+  inset: 0;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  z-index: 20;
+  background: rgba(6, 11, 25, 0.75);
+  backdrop-filter: blur(4px);
+}
+
+.birth-wizard__panel {
+  width: min(520px, 92vw);
+  background: linear-gradient(145deg, #0f1a31 0%, #15294a 100%);
+  border-radius: 20px;
+  padding: 32px;
+  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.birth-wizard__step {
+  margin: 0;
+  letter-spacing: 0.08em;
+  font-size: 0.85rem;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.birth-wizard__question {
+  margin: 0;
+  font-family: "Audiowide", system-ui, sans-serif;
+  font-size: clamp(1.6rem, 3vw, 2rem);
+  color: var(--text-light);
+}
+
+.birth-wizard__field {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+}
+
+.birth-wizard__field input,
+.birth-wizard__field select {
+  font-size: 1.1rem;
+  padding: 12px;
+  border-radius: 14px;
+  border: 1px solid var(--slate-700);
+  background: rgba(17, 24, 39, 0.85);
+  color: var(--text-light);
+  text-align: center;
+}
+
+.birth-wizard__field select {
+  text-align-last: center;
+}
+
+.birth-wizard__hint {
+  margin: 0;
+  font-size: 0.9rem;
+  color: var(--text-muted);
+}
+
+.birth-wizard__actions {
+  display: flex;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.birth-wizard__actions button {
+  flex: 1;
+  min-width: 140px;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: none;
+  font-weight: 600;
+  cursor: pointer;
+  transition: transform 0.15s ease, filter 0.15s ease;
+}
+
+.birth-wizard__actions button:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.birth-wizard__primary {
   background: var(--indigo-600);
   color: #fff;
 }
 
-.input.datetime {
-  border-color: var(--indigo-600);
-  box-shadow: 0 0 8px rgba(160, 112, 255, 0.4);
+.birth-wizard__primary:hover {
+  filter: brightness(1.1);
+  transform: scale(0.97);
+}
+
+.birth-wizard__secondary {
+  background: rgba(148, 163, 184, 0.18);
+  color: var(--text-light);
+  border: 1px solid rgba(148, 163, 184, 0.35);
+}
+
+.birth-wizard__secondary:hover {
+  background: rgba(148, 163, 184, 0.28);
+}
+
+.birth-wizard__skip {
+  width: 100%;
+  padding: 12px 20px;
+  border-radius: 999px;
+  border: 1px dashed rgba(129, 140, 248, 0.55);
+  background: rgba(79, 70, 229, 0.2);
+  color: var(--text-light);
+  font-weight: 600;
+  cursor: pointer;
+  transition: filter 0.15s ease, transform 0.15s ease;
+}
+
+.birth-wizard__skip:hover {
+  filter: brightness(1.1);
+  transform: scale(0.99);
+}
+
+@media (max-width: 520px) {
+  .birth-wizard__panel {
+    padding: 28px 24px;
+  }
+
+  .birth-wizard__actions button {
+    min-width: 120px;
+  }
 }


### PR DESCRIPTION
## Summary
- replace the landing date picker with a guided birth date wizard that blurs the background until completion
- add overlay styling for the new wizard and entry CTA while persisting the last chosen date summary
- drop the unused `react-datepicker` dependency and related overrides

## Testing
- npm run lint
- npm run test -- --run *(fails: existing expectation for formatSmall tiny numbers)*

------
https://chatgpt.com/codex/tasks/task_e_68cacb74ea08832fb86ea195bf9766e1