### PR TITLE
Add interactive life timeline slider to milestones page

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,0 +1,130 @@
+import { useMemo, type CSSProperties, type ChangeEvent, type ReactNode } from "react";
+
+const SLIDER_RESOLUTION = 1000;
+
+type Range = {
+  start: number;
+  end: number;
+};
+
+type Accent = "default" | "highlight" | "muted";
+
+type MarkerShape = "dot" | "triangle";
+
+const accentColors: Record<Accent, string> = {
+  default: "var(--indigo-300)",
+  highlight: "var(--indigo-100)",
+  muted: "var(--slate-700)"
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+export type TimelineEvent = {
+  id: string;
+  label: string;
+  value: number;
+  subLabel?: string;
+  placement?: "above" | "below";
+  markerShape?: MarkerShape;
+  accent?: Accent;
+};
+
+export type TimelineTick = {
+  id: string;
+  value: number;
+  label: string;
+};
+
+type Props = {
+  range: Range;
+  value: number;
+  onChange: (value: number) => void;
+  events: TimelineEvent[];
+  ticks?: TimelineTick[];
+  renderValue?: (value: number) => ReactNode;
+};
+
+export default function Timeline({ range, value, onChange, events, ticks = [], renderValue }: Props) {
+  const rawSpan = range.end - range.start;
+  const span = rawSpan <= 0 ? 1 : rawSpan;
+  const isInvalidRange = rawSpan <= 0;
+
+  const safeValue = clamp(value, range.start, range.end);
+  const sliderValue = ((safeValue - range.start) / span) * SLIDER_RESOLUTION;
+
+  const sortedEvents = useMemo(() => events.slice().sort((a, b) => a.value - b.value), [events]);
+  const sortedTicks = useMemo(() => ticks.slice().sort((a, b) => a.value - b.value), [ticks]);
+
+  const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
+    const ratio = Number(evt.target.value) / SLIDER_RESOLUTION;
+    const next = range.start + ratio * span;
+    onChange(clamp(next, range.start, range.end));
+  };
+
+  const valueNode = renderValue?.(safeValue);
+
+  if (isInvalidRange) return null;
+
+  return (
+    <div className="timeline">
+      {valueNode && <div className="timeline__value">{valueNode}</div>}
+
+      <input
+        type="range"
+        min={0}
+        max={SLIDER_RESOLUTION}
+        step={1}
+        value={sliderValue}
+        onChange={handleChange}
+        className="timeline__slider"
+      />
+
+      <div className="timeline__axis">
+        <div className="timeline__line" />
+        {sortedTicks.map(tick => {
+          const ratio = (clamp(tick.value, range.start, range.end) - range.start) / span;
+          const left = ratio * 100;
+          return (
+            <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
+              <span className="timeline__tick-line" />
+              <span className="timeline__tick-label">{tick.label}</span>
+            </div>
+          );
+        })}
+
+        {sortedEvents.map(event => {
+          const ratio = (clamp(event.value, range.start, range.end) - range.start) / span;
+          const left = ratio * 100;
+          const placement = event.placement ?? "above";
+          const markerShape = event.markerShape ?? "dot";
+          const accent: Accent = event.accent ?? "default";
+          const isClamped = event.value < range.start || event.value > range.end;
+
+          const eventClasses = ["timeline__event", `timeline__event--${placement}`];
+          if (isClamped) eventClasses.push("timeline__event--clamped");
+
+          const labelClasses = ["timeline__label", `timeline__label--${accent}`];
+
+          const markerStyle: CSSProperties = {
+            ["--marker-color" as const]: accentColors[accent]
+          };
+
+          return (
+            <div key={event.id} className={eventClasses.join(" ")} style={{ left: `${left}%` }}>
+              <div className={labelClasses.join(" ")}>
+                <span className="timeline__label-title">{event.label}</span>
+                {event.subLabel && (
+                  <span className="timeline__label-sub">{event.subLabel}</span>
+                )}
+              </div>
+              <span
+                className={`timeline__marker timeline__marker--${markerShape}`}
+                style={markerStyle}
+              />
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -221,6 +221,199 @@ body::before {
   padding: 8px; margin-top: 8px; font-size: .9rem;
 }
 
+.timeline-card {
+  width: 100%;
+  max-width: 960px;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+  margin-top: 32px;
+}
+
+.timeline {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.timeline__value {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-end;
+  flex-wrap: wrap;
+  gap: 12px;
+}
+
+.timeline__value-content {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.timeline__value-label {
+  font-size: .75rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.timeline__value-primary {
+  font-size: 1.6rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+.timeline__value-secondary {
+  font-size: .9rem;
+  color: var(--indigo-100);
+}
+
+.timeline__slider {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 100%;
+  margin: 8px 0 12px;
+  background: transparent;
+}
+
+.timeline__slider::-webkit-slider-runnable-track,
+.timeline__slider::-moz-range-track {
+  height: 10px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(79, 70, 229, 0.35), rgba(160, 112, 255, 0.4));
+  border: 1px solid rgba(79, 70, 229, 0.35);
+}
+
+.timeline__slider::-webkit-slider-thumb,
+.timeline__slider::-moz-range-thumb {
+  -webkit-appearance: none;
+  appearance: none;
+  width: 26px;
+  height: 26px;
+  border-radius: 50%;
+  background: var(--indigo-300);
+  border: 2px solid rgba(255, 255, 255, 0.25);
+  box-shadow: 0 0 14px rgba(160, 112, 255, 0.55);
+  cursor: pointer;
+}
+
+.timeline__slider::-webkit-slider-thumb {
+  margin-top: -9px;
+}
+
+.timeline__axis {
+  position: relative;
+  height: 220px;
+}
+
+.timeline__line {
+  position: absolute;
+  top: 50%;
+  left: 0;
+  right: 0;
+  height: 2px;
+  background: linear-gradient(90deg, rgba(79, 70, 229, 0.45), rgba(160, 112, 255, 0.6));
+  box-shadow: 0 0 16px rgba(160, 112, 255, 0.35);
+}
+
+.timeline__tick {
+  position: absolute;
+  top: 50%;
+  transform: translateX(-50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  pointer-events: none;
+}
+
+.timeline__tick-line {
+  width: 2px;
+  height: 18px;
+  background: var(--slate-700);
+}
+
+.timeline__tick-label {
+  font-size: .75rem;
+  color: var(--text-muted);
+  white-space: nowrap;
+}
+
+.timeline__event {
+  position: absolute;
+  top: 50%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  max-width: 220px;
+  text-align: center;
+  pointer-events: none;
+}
+
+.timeline__event--above { flex-direction: column; }
+.timeline__event--below { flex-direction: column-reverse; }
+
+.timeline__event--clamped {
+  opacity: .65;
+}
+
+.timeline__label {
+  padding: 10px 14px;
+  border-radius: 14px;
+  background: rgba(17, 24, 39, 0.85);
+  box-shadow: 0 12px 32px rgba(0, 0, 0, 0.45);
+}
+
+.timeline__label-title {
+  font-size: .95rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+.timeline__label-sub {
+  margin-top: 4px;
+  font-size: .75rem;
+  color: var(--text-muted);
+  display: block;
+}
+
+.timeline__label--highlight {
+  background: rgba(79, 70, 229, 0.4);
+}
+
+.timeline__label--muted {
+  background: rgba(31, 41, 55, 0.85);
+}
+
+.timeline__marker {
+  --marker-color: var(--indigo-300);
+}
+
+.timeline__marker--dot {
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: var(--marker-color);
+  box-shadow: 0 0 12px rgba(160, 112, 255, 0.45);
+}
+
+.timeline__marker--triangle {
+  width: 0;
+  height: 0;
+  border-left: 10px solid transparent;
+  border-right: 10px solid transparent;
+  border-top: 16px solid var(--marker-color);
+  filter: drop-shadow(0 0 10px rgba(160, 112, 255, 0.4));
+}
+
+@media (max-width: 720px) {
+  .timeline-card { margin-top: 28px; }
+  .timeline__axis { height: 260px; }
+  .timeline__label { max-width: 180px; }
+  .timeline__value-primary { font-size: 1.3rem; }
+}
+
 /* -----------------------------------------------------------
    9.  Navbar & footer
 ----------------------------------------------------------- */

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -1,36 +1,161 @@
-import { useEffect, useState } from "react";
-import { useNavigate, Link } from "react-router-dom";
-import { useMilestone } from "../hooks/useMilestone";
-import { TAB_ROWS } from "../utils/otherTimeUnitsConst";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { Link, useNavigate } from "react-router-dom";
+import dayjs from "dayjs";
+
+import Timeline, { type TimelineEvent, type TimelineTick } from "../components/Timeline";
 import MilestonePicker from "../components/MilestonePicker";
 import ResultBlock from "../components/ResultBlock";
-import AgeTable from "../components/AgeTable";    
-import Footer from "../components/Footer";    
+import AgeTable from "../components/AgeTable";
+import Footer from "../components/Footer";
+import { useMilestone } from "../hooks/useMilestone";
+import { TAB_ROWS } from "../utils/otherTimeUnitsConst";
+
 import "../css/index.css";
 
+const CENTURY_WINDOW = 100;
+const TICK_STEP_YEARS = 20;
+
+type TimelineData = {
+  range: { start: number; end: number };
+  events: TimelineEvent[];
+  ticks: TimelineTick[];
+  focus: number;
+};
+
+const clamp = (value: number, min: number, max: number) => Math.min(Math.max(value, min), max);
+
+const formatRelative = (now: dayjs.Dayjs, target: dayjs.Dayjs) => {
+  if (target.isSame(now, "day")) return "Today";
+
+  const diffYears = target.diff(now, "year", true);
+  const years = Math.abs(diffYears);
+  if (years >= 1) {
+    const value = years >= 10 ? Math.round(years) : years.toFixed(1);
+    return diffYears >= 0 ? `In ${value} years` : `${value} years ago`;
+  }
+
+  const diffMonths = target.diff(now, "month", true);
+  const months = Math.abs(diffMonths);
+  if (months >= 1) {
+    const value = months >= 10 ? Math.round(months) : months.toFixed(1);
+    return diffMonths >= 0 ? `In ${value} months` : `${value} months ago`;
+  }
+
+  const diffDays = target.startOf("day").diff(now.startOf("day"), "day");
+  if (diffDays === 0) return target.isAfter(now) ? "Later today" : "Earlier today";
+  if (diffDays === 1) return "Tomorrow";
+  if (diffDays === -1) return "Yesterday";
+  return diffDays > 0 ? `In ${diffDays} days` : `${Math.abs(diffDays)} days ago`;
+};
+
+const generateTicks = (start: dayjs.Dayjs, end: dayjs.Dayjs, stepYears: number): TimelineTick[] => {
+  if (stepYears <= 0) return [];
+
+  const ticks: TimelineTick[] = [];
+  const seen = new Set<number>();
+  const pushTick = (instant: dayjs.Dayjs, key: string) => {
+    const value = instant.valueOf();
+    if (value < start.valueOf() || value > end.valueOf()) return;
+    if (seen.has(value)) return;
+    seen.add(value);
+    ticks.push({ id: `${key}-${value}`, value, label: instant.format("YYYY") });
+  };
+
+  pushTick(start, "start");
+
+  const firstYear = Math.ceil(start.year() / stepYears) * stepYears;
+  let cursor = dayjs(`${firstYear}-01-01T00:00:00`);
+  if (cursor.isBefore(start)) cursor = cursor.add(stepYears, "year");
+
+  while (!cursor.isAfter(end)) {
+    pushTick(cursor, "tick");
+    cursor = cursor.add(stepYears, "year");
+  }
+
+  pushTick(end, "end");
+
+  return ticks.sort((a, b) => a.value - b.value);
+};
+
+const buildTimelineData = (birthDate: Date, birthTime: string): TimelineData | null => {
+  const base = dayjs(`${dayjs(birthDate).format("YYYY-MM-DD")}T${birthTime}`);
+  if (!base.isValid()) return null;
+
+  const now = dayjs();
+  const midpointValue = base.valueOf() + (now.valueOf() - base.valueOf()) / 2;
+  const midpoint = dayjs(midpointValue);
+  const start = midpoint.subtract(CENTURY_WINDOW, "year");
+  const end = midpoint.add(CENTURY_WINDOW, "year");
+
+  const tenThousandDays = base.add(10_000, "day");
+  const billionSeconds = base.add(1_000_000_000, "second");
+
+  const events: TimelineEvent[] = [
+    { id: "birth", label: "Birth", subLabel: base.format("MMM D, YYYY"), value: base.valueOf(), placement: "above" },
+    { id: "midpoint", label: "Midpoint", subLabel: midpoint.format("MMM D, YYYY"), value: midpoint.valueOf(), placement: "above", accent: "muted" },
+    { id: "today", label: "Today", subLabel: now.format("MMM D, YYYY"), value: now.valueOf(), placement: "below", markerShape: "triangle", accent: "highlight" },
+    { id: "tenk", label: "10,000 days old", subLabel: tenThousandDays.format("MMM D, YYYY"), value: tenThousandDays.valueOf(), placement: "below" },
+    { id: "billion", label: "1B seconds old", subLabel: billionSeconds.format("MMM D, YYYY HH:mm"), value: billionSeconds.valueOf(), placement: "above" }
+  ];
+
+  const ticks = generateTicks(start, end, TICK_STEP_YEARS);
+
+  return {
+    range: { start: start.valueOf(), end: end.valueOf() },
+    events,
+    ticks,
+    focus: clamp(now.valueOf(), start.valueOf(), end.valueOf())
+  };
+};
+
 export default function Milestones() {
-  /* data / actions */
   const { state, actions } = useMilestone();
-  const { amount, unit, result, error, targetDate, birthDate } = state;
+  const { amount, unit, result, error, targetDate, birthDate, birthTime } = state;
   const { setAmount, setUnit, calc } = actions;
-  const [stage, setStage] = useState<"age" | "milestone">("age"); 
+
   const [showMore, setShowMore] = useState(false);
   const [tab, setTab] = useState<keyof typeof TAB_ROWS>("Classic");
-  const allTabs = Object.keys(TAB_ROWS) as Array<keyof typeof TAB_ROWS>;
+  const [focusValue, setFocusValue] = useState(() => dayjs().valueOf());
+
+  const allTabs = useMemo(() => Object.keys(TAB_ROWS) as Array<keyof typeof TAB_ROWS>, []);
   const safeTab = allTabs.includes(tab) ? tab : "Classic";
   const rows = TAB_ROWS[safeTab];
+
   const nav = useNavigate();
 
-  useEffect(() => { if (!birthDate) nav("/"); }, [birthDate, nav]);
+  useEffect(() => {
+    if (!birthDate) nav("/");
+  }, [birthDate, nav]);
 
   useEffect(() => {
     document.body.style.backgroundColor = "#111827";
-    return () => { document.body.style.backgroundColor = ""; };
+    return () => {
+      document.body.style.backgroundColor = "";
+    };
+  }, []);
+
+  const timeline = useMemo(() => (birthDate ? buildTimelineData(birthDate, birthTime) : null), [birthDate, birthTime]);
+
+  useEffect(() => {
+    if (timeline) setFocusValue(timeline.focus);
+  }, [timeline]);
+
+  const renderFocus = useCallback((value: number) => {
+    const instant = dayjs(value);
+    const now = dayjs();
+    const relative = formatRelative(now, instant);
+
+    return (
+      <div className="timeline__value-content">
+        <span className="timeline__value-label">Focus date</span>
+        <span className="timeline__value-primary">{instant.format("MMM D, YYYY")}</span>
+        <span className="timeline__value-secondary">{relative}</span>
+      </div>
+    );
   }, []);
 
   return (
     <>
-      {/* ------------ nav bar ------------ */}
       <header className="navbar">
         <Link to="/">← Edit date of birth</Link>
       </header>
@@ -38,47 +163,55 @@ export default function Milestones() {
       <main className="page">
         <h1 className="title">AGE MILESTONES</h1>
 
-        {stage === "age" && (
-          <>
-            <div className="tabs">
-              {Object.keys(TAB_ROWS).map(t => (
-                <button
-                  key={t}
-                  className={`tab ${t === tab ? "tab--active" : ""}`}
-                  onClick={() => setTab(t as keyof typeof TAB_ROWS)}
-                >
-                  {t}
-                </button>
-              ))}
-            </div>
-            <div className="table-wrap">
-              <h2 className="subtitle">Your age in {tab.toLocaleLowerCase()} perspective</h2>
-              <AgeTable rows={rows} />
-            </div>
-            <button className="button" onClick={() => setStage("milestone")}>
-              Your next milestones →
+        <div className="tabs">
+          {allTabs.map(t => (
+            <button
+              key={t}
+              className={`tab ${t === safeTab ? "tab--active" : ""}`}
+              onClick={() => setTab(t)}
+            >
+              {t}
             </button>
-          </>
-        )}
-        {stage === "milestone" && (
-          <>
-            <div className="wrapper">
-              <MilestonePicker {...{ amount, setAmount, unit, setUnit }} />
-            </div>
-            <button className="button" onClick={calc}>
-              Tell me! 🧙‍♂️
-            </button>
-            <ResultBlock
-              result={result}
-              error={error}
-              showMore={showMore}
-              onMore={() => setShowMore(!showMore)}
-              target={targetDate}
+          ))}
+        </div>
+
+        <div className="table-wrap">
+          <h2 className="subtitle">Your age in {safeTab.toLocaleLowerCase()} perspective</h2>
+          <AgeTable rows={rows} />
+        </div>
+
+        {timeline && (
+          <section className="card timeline-card">
+            <span className="label">Explore your timeline</span>
+            <Timeline
+              range={timeline.range}
+              value={focusValue}
+              onChange={setFocusValue}
+              events={timeline.events}
+              ticks={timeline.ticks}
+              renderValue={renderFocus}
             />
-          </>
+          </section>
         )}
+
+        <div className="wrapper">
+          <MilestonePicker {...{ amount, setAmount, unit, setUnit }} />
+        </div>
+
+        <button className="button" onClick={calc}>
+          Tell me! 🧙‍♂️
+        </button>
+
+        <ResultBlock
+          result={result}
+          error={error}
+          showMore={showMore}
+          onMore={() => setShowMore(!showMore)}
+          target={targetDate}
+        />
       </main>
-      <Footer/>
+
+      <Footer />
     </>
   );
 }


### PR DESCRIPTION
## Summary
- add a reusable timeline slider component that renders labeled events and reference ticks
- embed the new time explorer under the milestone tables and remove the stage toggle
- style the timeline axis, slider, and markers to match the app visuals

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cae25962e0832f9065b175db85df7d