### PR TITLE
Enhance timeline interactions and grouping

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -1,8 +1,27 @@
-import { useMemo, type CSSProperties, type ChangeEvent, type ReactNode } from "react";
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type CSSProperties,
+  type ChangeEvent,
+  type PointerEvent as ReactPointerEvent,
+  type ReactNode
+} from "react";
+
+import { useElementSize } from "../hooks/useElementSize";
+import { useOutsideClick } from "../hooks/useOutsideClick";
 
 const SLIDER_RESOLUTION = 10000;
+const GROUPING_GAP_PX = 48;
+const SUB_TIMELINE_MIN_WIDTH = 320;
+const SUB_TIMELINE_PADDING = 40;
+const SUB_TIMELINE_CONNECTOR_HEIGHT = 48;
+const SUB_TIMELINE_MARGIN_RATIO = 0.2;
+const MIN_SUB_TIMELINE_SPAN = 86_400_000;
 
-type Range = {
+export type Range = {
   start: number;
   end: number;
 };
@@ -44,22 +63,259 @@ type Props = {
   renderValue?: (value: number) => ReactNode;
 };
 
+type PositionedEvent = {
+  event: TimelineEvent;
+  ratio: number;
+};
+
+type RenderSingle = {
+  type: "single";
+  id: string;
+  event: TimelineEvent;
+  leftPercent: number;
+  ratio: number;
+};
+
+type RenderGroup = {
+  type: "group";
+  id: string;
+  events: TimelineEvent[];
+  leftPercent: number;
+  ratio: number;
+  startRatio: number;
+  endRatio: number;
+  valueRange: Range;
+};
+
+type RenderItem = RenderSingle | RenderGroup;
+
+type SubTimelineProps = {
+  axisWidth: number;
+  group: RenderGroup;
+  range: Range;
+  onClose: () => void;
+};
+
+const getRatio = (value: number, range: Range, span: number) => {
+  if (span <= 0) return 0;
+  const clamped = clamp(value, range.start, range.end);
+  return (clamped - range.start) / span;
+};
+
+const toPercent = (ratio: number) => ratio * 100;
+
+const buildRenderItems = (
+  events: TimelineEvent[],
+  range: Range,
+  span: number,
+  axisWidth: number
+): RenderItem[] => {
+  if (!events.length) return [];
+
+  const positioned: PositionedEvent[] = events.map(event => ({
+    event,
+    ratio: getRatio(event.value, range, span)
+  }));
+
+  if (axisWidth <= 0) {
+    return positioned.map(item => ({
+      type: "single",
+      id: item.event.id,
+      event: item.event,
+      leftPercent: toPercent(item.ratio),
+      ratio: item.ratio
+    }));
+  }
+
+  const items: RenderItem[] = [];
+  let buffer: PositionedEvent[] = [];
+
+  const flush = () => {
+    if (!buffer.length) return;
+    if (buffer.length === 1) {
+      const item = buffer[0];
+      items.push({
+        type: "single",
+        id: item.event.id,
+        event: item.event,
+        leftPercent: toPercent(item.ratio),
+        ratio: item.ratio
+      });
+      buffer = [];
+      return;
+    }
+
+    const first = buffer[0];
+    const last = buffer[buffer.length - 1];
+    const ratios = buffer.map(b => b.ratio);
+    const avg = ratios.reduce((acc, current) => acc + current, 0) / buffer.length;
+    const rangeValues = buffer.map(b => clamp(b.event.value, range.start, range.end));
+    const startValue = Math.min(...rangeValues);
+    const endValue = Math.max(...rangeValues);
+
+    items.push({
+      type: "group",
+      id: buffer.map(b => b.event.id).join("::"),
+      events: buffer.map(b => b.event),
+      leftPercent: toPercent(avg),
+      ratio: avg,
+      startRatio: first.ratio,
+      endRatio: last.ratio,
+      valueRange: { start: startValue, end: endValue }
+    });
+
+    buffer = [];
+  };
+
+  for (const item of positioned) {
+    if (!buffer.length) {
+      buffer.push(item);
+      continue;
+    }
+
+    const prev = buffer[buffer.length - 1];
+    const distancePx = Math.abs(item.ratio - prev.ratio) * axisWidth;
+    if (distancePx < GROUPING_GAP_PX) {
+      buffer.push(item);
+    } else {
+      flush();
+      buffer.push(item);
+    }
+  }
+
+  flush();
+
+  return items;
+};
+
+const createSubRange = (group: RenderGroup, range: Range): Range => {
+  const { start, end } = group.valueRange;
+  const rawSpan = Math.max(end - start, 0);
+  const margin = Math.max(rawSpan * SUB_TIMELINE_MARGIN_RATIO, MIN_SUB_TIMELINE_SPAN);
+
+  let nextStart = clamp(start - margin, range.start, range.end);
+  let nextEnd = clamp(end + margin, range.start, range.end);
+
+  if (nextEnd - nextStart < 1) {
+    const middle = (nextStart + nextEnd) / 2;
+    nextStart = Math.max(range.start, middle - MIN_SUB_TIMELINE_SPAN / 2);
+    nextEnd = Math.min(range.end, middle + MIN_SUB_TIMELINE_SPAN / 2);
+  }
+
+  if (nextEnd <= nextStart) {
+    nextEnd = Math.min(range.end, nextStart + MIN_SUB_TIMELINE_SPAN);
+  }
+
+  return { start: nextStart, end: nextEnd };
+};
+
 export default function Timeline({ range, value, onChange, events, ticks = [], renderValue }: Props) {
   const rawSpan = range.end - range.start;
   const span = rawSpan <= 0 ? 1 : rawSpan;
   const isInvalidRange = rawSpan <= 0;
 
   const safeValue = clamp(value, range.start, range.end);
-  const sliderValue = ((safeValue - range.start) / span) * SLIDER_RESOLUTION;
+  const valueRatio = getRatio(safeValue, range, span);
+  const sliderValue = valueRatio * SLIDER_RESOLUTION;
+
+  const [axisRef, axisSize] = useElementSize<HTMLDivElement>();
+  const axisNodeRef = useRef<HTMLDivElement | null>(null);
+  const setAxisRef = useCallback(
+    (node: HTMLDivElement | null) => {
+      axisNodeRef.current = node;
+      axisRef(node);
+    },
+    [axisRef]
+  );
 
   const sortedEvents = useMemo(() => events.slice().sort((a, b) => a.value - b.value), [events]);
   const sortedTicks = useMemo(() => ticks.slice().sort((a, b) => a.value - b.value), [ticks]);
 
-  const handleChange = (evt: ChangeEvent<HTMLInputElement>) => {
+  const renderItems = useMemo(
+    () => buildRenderItems(sortedEvents, range, span, axisSize.width),
+    [sortedEvents, range, span, axisSize.width]
+  );
+
+  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
+
+  const activeGroup = useMemo(() => {
+    if (!activeGroupId) return null;
+    return (
+      renderItems.find(item => item.type === "group" && item.id === activeGroupId) as RenderGroup | undefined
+    ) ?? null;
+  }, [activeGroupId, renderItems]);
+
+  useEffect(() => {
+    if (!activeGroupId) return;
+    if (activeGroup) return;
+    setActiveGroupId(null);
+  }, [activeGroup, activeGroupId]);
+
+  useEffect(() => {
+    if (!activeGroupId) return;
+    const handleKey = (evt: KeyboardEvent) => {
+      if (evt.key === "Escape") setActiveGroupId(null);
+    };
+    window.addEventListener("keydown", handleKey);
+    return () => window.removeEventListener("keydown", handleKey);
+  }, [activeGroupId]);
+
+  const updateValueFromClientX = useCallback(
+    (clientX: number) => {
+      const axis = axisNodeRef.current;
+      if (!axis) return;
+      const rect = axis.getBoundingClientRect();
+      if (rect.width === 0) return;
+      const relative = clamp((clientX - rect.left) / rect.width, 0, 1);
+      const next = range.start + relative * span;
+      onChange(clamp(next, range.start, range.end));
+    },
+    [onChange, range.end, range.start, span]
+  );
+
+  const draggingRef = useRef(false);
+
+  const handleFocusPointerDown = useCallback(
+    (evt: ReactPointerEvent<HTMLDivElement>) => {
+      evt.preventDefault();
+      draggingRef.current = true;
+      const target = evt.target as HTMLElement | null;
+      if (target && typeof target.setPointerCapture === "function") {
+        target.setPointerCapture(evt.pointerId);
+      }
+      updateValueFromClientX(evt.clientX);
+    },
+    [updateValueFromClientX]
+  );
+
+  const handleFocusPointerMove = useCallback(
+    (evt: ReactPointerEvent<HTMLDivElement>) => {
+      if (!draggingRef.current) return;
+      updateValueFromClientX(evt.clientX);
+    },
+    [updateValueFromClientX]
+  );
+
+  const handleFocusPointerUp = useCallback((evt: ReactPointerEvent<HTMLDivElement>) => {
+    if (!draggingRef.current) return;
+    draggingRef.current = false;
+    const target = evt.target as HTMLElement | null;
+    if (target && typeof target.releasePointerCapture === "function") {
+      target.releasePointerCapture(evt.pointerId);
+    }
+  }, []);
+
+  const handleSliderChange = (evt: ChangeEvent<HTMLInputElement>) => {
     const ratio = Number(evt.target.value) / SLIDER_RESOLUTION;
     const next = range.start + ratio * span;
     onChange(clamp(next, range.start, range.end));
   };
+
+  const handleGroupToggle = useCallback((groupId: string) => {
+    setActiveGroupId(prev => (prev === groupId ? null : groupId));
+  }, []);
+
+  const handleCloseSubTimeline = useCallback(() => setActiveGroupId(null), []);
 
   const valueNode = renderValue?.(safeValue);
 
@@ -75,15 +331,17 @@ export default function Timeline({ range, value, onChange, events, ticks = [], r
         max={SLIDER_RESOLUTION}
         step={1}
         value={sliderValue}
-        onChange={handleChange}
+        onChange={handleSliderChange}
         className="timeline__slider"
+        aria-label="Timeline focus"
       />
 
-      <div className="timeline__axis">
+      <div className="timeline__axis" ref={setAxisRef}>
         <div className="timeline__line" />
+
         {sortedTicks.map(tick => {
-          const ratio = (clamp(tick.value, range.start, range.end) - range.start) / span;
-          const left = ratio * 100;
+          const ratio = getRatio(tick.value, range, span);
+          const left = toPercent(ratio);
           return (
             <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
               <span className="timeline__tick-line" />
@@ -92,39 +350,149 @@ export default function Timeline({ range, value, onChange, events, ticks = [], r
           );
         })}
 
-        {sortedEvents.map(event => {
-          const ratio = (clamp(event.value, range.start, range.end) - range.start) / span;
-          const left = ratio * 100;
-          const placement = event.placement ?? "above";
-          const markerShape = event.markerShape ?? "dot";
-          const accent: Accent = event.accent ?? "default";
-          const isClamped = event.value < range.start || event.value > range.end;
-
-          const eventClasses = ["timeline__event", `timeline__event--${placement}`];
-          if (isClamped) eventClasses.push("timeline__event--clamped");
-
-          const labelClasses = ["timeline__label", `timeline__label--${accent}`];
-
-          const markerStyle: CSSProperties = {
-            ["--marker-color"]: accentColors[accent]
-          };
+        {renderItems.map(item => {
+          if (item.type === "group") {
+            const isActive = activeGroup?.id === item.id;
+            return (
+              <button
+                key={item.id}
+                type="button"
+                className={`timeline__group ${isActive ? "timeline__group--active" : ""}`.trim()}
+                style={{ left: `${item.leftPercent}%` }}
+                onClick={() => handleGroupToggle(item.id)}
+                aria-pressed={isActive}
+                aria-label={`${item.events.length} overlapping events`}
+              >
+                <span className="timeline__group-count">{item.events.length}</span>
+              </button>
+            );
+          }
 
           return (
-            <div key={event.id} className={eventClasses.join(" ")} style={{ left: `${left}%` }}>
-              <div className={labelClasses.join(" ")}>
-                <span className="timeline__label-title">{event.label}</span>
-                {event.subLabel && (
-                  <span className="timeline__label-sub">{event.subLabel}</span>
-                )}
-              </div>
-              <span
-                className={`timeline__marker timeline__marker--${markerShape}`}
-                style={markerStyle}
-              />
-            </div>
+            <EventElement
+              key={item.event.id}
+              event={item.event}
+              leftPercent={item.leftPercent}
+              variant="main"
+              range={range}
+            />
           );
         })}
+
+        <div
+          className="timeline__focus"
+          style={{ left: `${toPercent(valueRatio)}%` }}
+          onPointerDown={handleFocusPointerDown}
+          onPointerMove={handleFocusPointerMove}
+          onPointerUp={handleFocusPointerUp}
+          role="presentation"
+        >
+          <span className="timeline__focus-handle" />
+          <span className="timeline__focus-stem" />
+        </div>
       </div>
+
+      {activeGroup && axisSize.width > 0 && (
+        <SubTimeline axisWidth={axisSize.width} group={activeGroup} range={range} onClose={handleCloseSubTimeline} />
+      )}
     </div>
   );
 }
+
+const SubTimeline = ({ axisWidth, group, range, onClose }: SubTimelineProps) => {
+  const containerRef = useRef<HTMLDivElement>(null);
+  useOutsideClick(containerRef, onClose);
+
+  const subRange = useMemo(() => createSubRange(group, range), [group, range]);
+  const subSpan = subRange.end - subRange.start || 1;
+
+  const subEvents = useMemo(
+    () =>
+      group.events.map(event => ({
+        event,
+        leftPercent: toPercent(getRatio(event.value, subRange, subSpan))
+      })),
+    [group.events, subRange, subSpan]
+  );
+
+  const startPx = axisWidth * group.startRatio;
+  const endPx = axisWidth * group.endRatio;
+  const baseWidth = Math.max(endPx - startPx, 0);
+  const desiredWidth = Math.max(baseWidth + SUB_TIMELINE_PADDING * 2, SUB_TIMELINE_MIN_WIDTH);
+  const width = Math.min(axisWidth, desiredWidth);
+  const center = axisWidth * group.ratio;
+  const left = clamp(center - width / 2, 0, Math.max(axisWidth - width, 0));
+  const right = left + width;
+
+  return (
+    <div className="timeline__subtimeline">
+      <svg
+        className="timeline__subtimeline-connectors"
+        width={axisWidth}
+        height={SUB_TIMELINE_CONNECTOR_HEIGHT}
+        viewBox={`0 0 ${axisWidth} ${SUB_TIMELINE_CONNECTOR_HEIGHT}`}
+        preserveAspectRatio="none"
+      >
+        <line x1={startPx} y1={0} x2={left} y2={SUB_TIMELINE_CONNECTOR_HEIGHT} />
+        <line x1={endPx} y1={0} x2={right} y2={SUB_TIMELINE_CONNECTOR_HEIGHT} />
+      </svg>
+
+      <div
+        ref={containerRef}
+        className="timeline__subtimeline-box"
+        style={{ width: `${width}px`, left: `${left}px` }}
+      >
+        <div className="timeline__subtimeline-axis">
+          <div className="timeline__line" />
+          {subEvents.map(item => (
+            <EventElement
+              key={`sub-${item.event.id}`}
+              event={item.event}
+              leftPercent={item.leftPercent}
+              variant="sub"
+              range={subRange}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+type EventElementProps = {
+  event: TimelineEvent;
+  leftPercent: number;
+  variant: "main" | "sub";
+  range: Range;
+};
+
+const EventElement = ({ event, leftPercent, variant, range }: EventElementProps) => {
+  const placement = event.placement ?? "above";
+  const markerShape = event.markerShape ?? "dot";
+  const accent: Accent = event.accent ?? "default";
+  const isClamped = event.value < range.start || event.value > range.end;
+
+  const eventClasses = [
+    "timeline__event",
+    `timeline__event--${placement}`,
+    `timeline__event--${variant}`
+  ];
+
+  if (variant === "main" && isClamped) eventClasses.push("timeline__event--clamped");
+
+  const labelClasses = ["timeline__label", `timeline__label--${accent}`];
+
+  const markerStyle: CSSProperties = {
+    ["--marker-color" as string]: accentColors[accent]
+  };
+
+  return (
+    <div className={eventClasses.join(" ")} style={{ left: `${leftPercent}%` }}>
+      <div className={labelClasses.join(" ")}>
+        <span className="timeline__label-title">{event.label}</span>
+        {event.subLabel && <span className="timeline__label-sub">{event.subLabel}</span>}
+      </div>
+      <span className={`timeline__marker timeline__marker--${markerShape}`} style={markerStyle} />
+    </div>
+  );
+};

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -231,6 +231,7 @@ body::before {
 }
 
 .timeline {
+  position: relative;
   display: flex;
   flex-direction: column;
   gap: 16px;
@@ -269,67 +270,50 @@ body::before {
 }
 
 .timeline__slider {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 100%;
-  margin: 8px 0 12px;
-  background: transparent;
-}
-
-.timeline__slider::-webkit-slider-runnable-track,
-.timeline__slider::-moz-range-track {
-  height: 10px;
-  border-radius: 999px;
-  background: linear-gradient(90deg, rgba(79, 70, 229, 0.35), rgba(160, 112, 255, 0.4));
-  border: 1px solid rgba(79, 70, 229, 0.35);
-}
-
-.timeline__slider::-webkit-slider-thumb,
-.timeline__slider::-moz-range-thumb {
-  -webkit-appearance: none;
-  appearance: none;
-  width: 26px;
-  height: 26px;
-  border-radius: 50%;
-  background: var(--indigo-300);
-  border: 2px solid rgba(255, 255, 255, 0.25);
-  box-shadow: 0 0 14px rgba(160, 112, 255, 0.55);
-  cursor: pointer;
-}
-
-.timeline__slider::-webkit-slider-thumb {
-  margin-top: -9px;
+  position: absolute;
+  width: 1px;
+  height: 1px;
+  padding: 0;
+  margin: -1px;
+  border: 0;
+  overflow: hidden;
+  clip: rect(0 0 0 0);
+  clip-path: inset(50%);
+  white-space: nowrap;
 }
 
 .timeline__axis {
   position: relative;
-  height: 220px;
+  height: 260px;
+  --timeline-line-top: 60%;
 }
 
 .timeline__line {
   position: absolute;
-  top: 50%;
+  top: var(--timeline-line-top);
   left: 0;
   right: 0;
   height: 2px;
   background: linear-gradient(90deg, rgba(79, 70, 229, 0.45), rgba(160, 112, 255, 0.6));
   box-shadow: 0 0 16px rgba(160, 112, 255, 0.35);
+  z-index: 0;
 }
 
 .timeline__tick {
   position: absolute;
-  top: 50%;
-  transform: translateX(-50%);
+  top: var(--timeline-line-top);
+  transform: translate(-50%, 0);
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 8px;
+  gap: 6px;
   pointer-events: none;
+  z-index: 1;
 }
 
 .timeline__tick-line {
   width: 2px;
-  height: 18px;
+  height: 16px;
   background: var(--slate-700);
 }
 
@@ -339,23 +323,105 @@ body::before {
   white-space: nowrap;
 }
 
+
+.timeline__focus,
+.timeline__group,
 .timeline__event {
   position: absolute;
-  top: 50%;
-  transform: translate(-50%, -50%);
+  top: var(--timeline-line-top);
+  transform: translate(-50%, calc(-100% - 12px));
+}
+
+.timeline__event {
   display: flex;
   align-items: center;
   gap: 10px;
   max-width: 220px;
   text-align: center;
   pointer-events: none;
+  z-index: 2;
 }
 
 .timeline__event--above { flex-direction: column; }
 .timeline__event--below { flex-direction: column-reverse; }
 
+.timeline__event--sub { max-width: 200px; }
+
 .timeline__event--clamped {
   opacity: .65;
+}
+
+.timeline__group {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 6px;
+  padding: 0;
+  border: none;
+  background: none;
+  cursor: pointer;
+  pointer-events: auto;
+  z-index: 3;
+  touch-action: manipulation;
+}
+
+.timeline__group-count {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 32px;
+  min-height: 32px;
+  padding: 4px 12px;
+  border-radius: 999px;
+  background: rgba(79, 70, 229, 0.85);
+  color: #fff;
+  font-weight: 600;
+  font-size: .85rem;
+  box-shadow: 0 12px 28px rgba(79, 70, 229, 0.35);
+  transition: background .2s ease, transform .2s ease, box-shadow .2s ease;
+}
+
+.timeline__group--active .timeline__group-count {
+  background: var(--indigo-100);
+  color: var(--slate-900);
+  box-shadow: 0 16px 32px rgba(160, 112, 255, 0.4);
+}
+
+.timeline__group:focus-visible {
+  outline: 2px solid var(--indigo-100);
+  outline-offset: 4px;
+  border-radius: 999px;
+}
+
+.timeline__focus {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  gap: 8px;
+  cursor: grab;
+  pointer-events: auto;
+  z-index: 4;
+  touch-action: none;
+}
+
+.timeline__focus:active {
+  cursor: grabbing;
+}
+
+.timeline__focus-handle {
+  width: 0;
+  height: 0;
+  border-left: 12px solid transparent;
+  border-right: 12px solid transparent;
+  border-top: 20px solid var(--indigo-100);
+  filter: drop-shadow(0 16px 26px rgba(79, 70, 229, 0.55));
+}
+
+.timeline__focus-stem {
+  width: 2px;
+  height: 20px;
+  border-radius: 999px;
+  background: linear-gradient(180deg, rgba(79, 70, 229, 0.6), rgba(160, 112, 255, 0.65));
 }
 
 .timeline__label {
@@ -405,6 +471,55 @@ body::before {
   border-right: 10px solid transparent;
   border-top: 16px solid var(--marker-color);
   filter: drop-shadow(0 0 10px rgba(160, 112, 255, 0.4));
+}
+
+.timeline__subtimeline {
+  position: relative;
+  margin-top: 48px;
+  padding-top: 48px;
+  padding-bottom: 40px;
+  min-height: 280px;
+  --timeline-sub-gap: 48px;
+}
+
+.timeline__subtimeline-connectors {
+  position: absolute;
+  top: calc(-1 * var(--timeline-sub-gap));
+  left: 0;
+  width: 100%;
+  height: var(--timeline-sub-gap);
+  pointer-events: none;
+}
+
+.timeline__subtimeline-connectors line {
+  stroke: rgba(160, 112, 255, 0.6);
+  stroke-width: 2;
+}
+
+.timeline__subtimeline-box {
+  position: absolute;
+  top: 0;
+  padding: 24px 28px;
+  background: rgba(17, 24, 39, 0.95);
+  border: 1px solid rgba(79, 70, 229, 0.35);
+  border-radius: 20px;
+  box-shadow: 0 24px 48px rgba(0, 0, 0, 0.55);
+  pointer-events: auto;
+}
+
+.timeline__subtimeline-axis {
+  position: relative;
+  height: 200px;
+  --timeline-line-top: 68%;
+}
+
+.timeline__subtimeline-axis .timeline__event {
+  z-index: 2;
+  transform: translate(-50%, calc(-100% - 8px));
+}
+
+.timeline__subtimeline-axis .timeline__label {
+  backdrop-filter: blur(6px);
 }
 
 @media (max-width: 720px) {

--- a/src/hooks/useElementSize.ts
+++ b/src/hooks/useElementSize.ts
@@ -1,0 +1,46 @@
+import { useCallback, useEffect, useRef, useState } from "react";
+
+type Size = {
+  width: number;
+  height: number;
+};
+
+export const useElementSize = <T extends HTMLElement>(): [
+  (node: T | null) => void,
+  Size
+] => {
+  const observerRef = useRef<ResizeObserver | null>(null);
+  const [size, setSize] = useState<Size>({ width: 0, height: 0 });
+
+  const cleanup = useCallback(() => {
+    observerRef.current?.disconnect();
+    observerRef.current = null;
+  }, []);
+
+  const ref = useCallback(
+    (node: T | null) => {
+      cleanup();
+      if (!node) return;
+
+      const updateSize = (target: HTMLElement) => {
+        const rect = target.getBoundingClientRect();
+        setSize({ width: rect.width, height: rect.height });
+      };
+
+      observerRef.current = new ResizeObserver(entries => {
+        const entry = entries[0];
+        if (!entry) return;
+        const target = entry.target as HTMLElement;
+        updateSize(target);
+      });
+
+      observerRef.current.observe(node);
+      updateSize(node);
+    },
+    [cleanup]
+  );
+
+  useEffect(() => cleanup, [cleanup]);
+
+  return [ref, size];
+};

--- a/src/hooks/useOutsideClick.ts
+++ b/src/hooks/useOutsideClick.ts
@@ -1,0 +1,24 @@
+import { useEffect, type RefObject } from "react";
+
+export const useOutsideClick = <T extends HTMLElement>(
+  ref: RefObject<T | null>,
+  handler: () => void
+) => {
+  useEffect(() => {
+    const listener = (evt: MouseEvent | TouchEvent) => {
+      const node = ref.current;
+      if (!node) return;
+      const target = evt.target as Node | null;
+      if (target && node.contains(target)) return;
+      handler();
+    };
+
+    document.addEventListener("mousedown", listener);
+    document.addEventListener("touchstart", listener);
+
+    return () => {
+      document.removeEventListener("mousedown", listener);
+      document.removeEventListener("touchstart", listener);
+    };
+  }, [handler, ref]);
+};


### PR DESCRIPTION
## Summary
- replace the hidden range knob with a draggable focus triangle and reposition timeline markers above the axis
- group overlapping milestones into aggregated markers that open a zoomed sub-timeline with dedicated connectors
- add reusable hooks for observing element size and outside clicks while updating styles for new timeline visuals

## Testing
- npm run lint
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68caf0f08540832fb593d75a09fe55c5