### PR TITLE
Adjust timeline styling and data range

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -604,23 +604,19 @@ body::before {
   width: var(--timeline-marker-size);
   height: var(--timeline-marker-size);
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0.45) 30%, var(--marker-color) 75%);
-  border: 2px solid rgba(226, 232, 240, 0.55);
-  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.35);
+  background: var(--marker-color);
+  border: 1px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 10px 22px rgba(15, 23, 42, 0.35);
   transition: transform .2s ease, box-shadow .2s ease;
 }
 
 .timeline__marker::after {
-  content: "";
-  position: absolute;
-  inset: 4px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.18);
+  content: none;
 }
 
 .timeline__event:hover .timeline__marker {
   transform: scale(1.08);
-  box-shadow: 0 12px 26px rgba(79, 70, 229, 0.45);
+  box-shadow: 0 12px 26px rgba(15, 23, 42, 0.4);
 }
 
 .timeline__subtimeline {
@@ -644,16 +640,13 @@ body::before {
 .timeline__subtimeline-connectors line {
   stroke: rgba(160, 112, 255, 0.6);
   stroke-width: 1;
+  stroke-linecap: round;
 }
 
-.timeline__subtimeline-box {
+.timeline__subtimeline-surface {
   position: absolute;
   top: 0;
   padding: var(--timeline-sub-padding-y, 18px) var(--timeline-sub-padding-x, 20px);
-  background: rgba(17, 24, 39, 0.95);
-  border: 1px solid rgba(79, 70, 229, 0.35);
-  border-radius: 18px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
   pointer-events: auto;
 }
 

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -11,6 +11,7 @@ import { TAB_ROWS } from "../utils/timePerspectivesConstants.ts";
 import "../css/index.css";
 
 const CENTURY_WINDOW = 40;
+const PRE_BIRTH_WINDOW_YEARS = 20;
 const TICK_STEP_YEARS = 10;
 
 type TimelineData = {
@@ -85,7 +86,7 @@ const buildTimelineData = (birthDate: Date, birthTime: string): TimelineData | n
   const now = dayjs();
   const midpointValue = base.valueOf() + (now.valueOf() - base.valueOf()) / 2;
   const midpoint = dayjs(midpointValue);
-  const start = midpoint.subtract(CENTURY_WINDOW, "year");
+  const start = base.subtract(PRE_BIRTH_WINDOW_YEARS, "year");
   const end = midpoint.add(CENTURY_WINDOW, "year");
 
   const tenThousandDays = base.add(10_000, "day");
@@ -115,7 +116,8 @@ const buildTimelineData = (birthDate: Date, birthTime: string): TimelineData | n
       value: now.valueOf(),
       placement: "below",
       markerShape: "triangle",
-      accent: "highlight"
+      accent: "highlight",
+      showRelativeLabel: false
     },
     {
       id: "tenk",


### PR DESCRIPTION
## Summary
- start the primary timeline 20 years before the birth date and hide the relative label on the today marker
- rework sub-timeline connectors to originate from the grouped marker and remove the boxed background
- simplify timeline marker visuals to use a flat fill with a light shadow

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd89d048fc832f8cf7265dbe16c597