### PR TITLE
Refine timeline zoom styling

### DIFF
--- a/src/css/index.css
+++ b/src/css/index.css
@@ -604,23 +604,15 @@ body::before {
   width: var(--timeline-marker-size);
   height: var(--timeline-marker-size);
   border-radius: 50%;
-  background: radial-gradient(circle at 30% 30%, rgba(255, 255, 255, 0.85) 0%, rgba(255, 255, 255, 0.45) 30%, var(--marker-color) 75%);
-  border: 2px solid rgba(226, 232, 240, 0.55);
-  box-shadow: 0 10px 22px rgba(79, 70, 229, 0.35);
+  background: var(--marker-color);
+  border: 2px solid rgba(255, 255, 255, 0.18);
+  box-shadow: 0 12px 28px rgba(15, 23, 42, 0.45);
   transition: transform .2s ease, box-shadow .2s ease;
 }
 
-.timeline__marker::after {
-  content: "";
-  position: absolute;
-  inset: 4px;
-  border-radius: 50%;
-  background: rgba(255, 255, 255, 0.18);
-}
-
 .timeline__event:hover .timeline__marker {
-  transform: scale(1.08);
-  box-shadow: 0 12px 26px rgba(79, 70, 229, 0.45);
+  transform: scale(1.06);
+  box-shadow: 0 18px 34px rgba(15, 23, 42, 0.5);
 }
 
 .timeline__subtimeline {
@@ -642,18 +634,15 @@ body::before {
 }
 
 .timeline__subtimeline-connectors line {
-  stroke: rgba(160, 112, 255, 0.6);
-  stroke-width: 1;
+  stroke: rgba(165, 180, 252, 0.55);
+  stroke-width: 1.5;
 }
 
-.timeline__subtimeline-box {
+.timeline__subtimeline-axis-wrapper {
   position: absolute;
   top: 0;
-  padding: var(--timeline-sub-padding-y, 18px) var(--timeline-sub-padding-x, 20px);
-  background: rgba(17, 24, 39, 0.95);
-  border: 1px solid rgba(79, 70, 229, 0.35);
-  border-radius: 18px;
-  box-shadow: 0 20px 40px rgba(0, 0, 0, 0.5);
+  left: 0;
+  height: 100%;
   pointer-events: auto;
 }
 

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -10,7 +10,8 @@ import { useMilestone } from "../hooks/useMilestone";
 import { TAB_ROWS } from "../utils/timePerspectivesConstants.ts";
 import "../css/index.css";
 
-const CENTURY_WINDOW = 40;
+const FUTURE_WINDOW_YEARS = 40;
+const LOOKBACK_YEARS = 20;
 const TICK_STEP_YEARS = 10;
 
 type TimelineData = {
@@ -85,8 +86,12 @@ const buildTimelineData = (birthDate: Date, birthTime: string): TimelineData | n
   const now = dayjs();
   const midpointValue = base.valueOf() + (now.valueOf() - base.valueOf()) / 2;
   const midpoint = dayjs(midpointValue);
-  const start = midpoint.subtract(CENTURY_WINDOW, "year");
-  const end = midpoint.add(CENTURY_WINDOW, "year");
+  const start = base.subtract(LOOKBACK_YEARS, "year");
+  let end = midpoint.add(FUTURE_WINDOW_YEARS, "year");
+
+  if (!end.isAfter(start)) {
+    end = start.add(FUTURE_WINDOW_YEARS * 2, "year");
+  }
 
   const tenThousandDays = base.add(10_000, "day");
   const billionSeconds = base.add(1_000_000_000, "second");


### PR DESCRIPTION
## Summary
- start the main timeline 20 years before birth while keeping a forward-looking window
- rework sub-timeline connectors to originate from the group marker and span the zoomed range without the surrounding box
- simplify marker styling and suppress the live countdown on today for a calmer presentation

## Testing
- npm run build
- npm run lint *(warns about an existing react-refresh rule in BirthDateContext.tsx)*

------
https://chatgpt.com/codex/tasks/task_e_68cd8f059e54832f9bbb2a72f2578a78