### PR TITLE
Improve timeline spacing and slider placement

### DIFF
--- a/src/components/Timeline.tsx
+++ b/src/components/Timeline.tsx
@@ -407,8 +407,6 @@ export default function Timeline({ range, value, onChange, events, ticks = [], r
 
   return (
     <div className="timeline">
-      {valueNode && <div className="timeline__value">{valueNode}</div>}
-
       <input
         type="range"
         min={0}
@@ -420,74 +418,78 @@ export default function Timeline({ range, value, onChange, events, ticks = [], r
         aria-label="Timeline focus"
       />
 
-      <div className="timeline__axis" ref={setAxisRef}>
-        <div className="timeline__line" />
+      <div className="timeline__stack">
+        <div className="timeline__axis" ref={setAxisRef}>
+          <div className="timeline__line" />
 
-        {sortedTicks.map(tick => {
-          const ratio = getRatio(tick.value, range, span);
-          const left = toPercent(ratio);
-          return (
-            <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
-              <span className="timeline__tick-line" />
-              <span className="timeline__tick-label">{tick.label}</span>
-            </div>
-          );
-        })}
-
-        {renderItems.map(item => {
-          if (item.type === "group") {
-            const isActive = activeGroup?.id === item.id;
+          {sortedTicks.map(tick => {
+            const ratio = getRatio(tick.value, range, span);
+            const left = toPercent(ratio);
             return (
-              <button
-                key={item.id}
-                type="button"
-                ref={node => setGroupNode(item.id, node)}
-                className={`timeline__group ${isActive ? "timeline__group--active" : ""}`.trim()}
-                style={{ left: `${item.leftPercent}%` }}
-                onClick={() => handleGroupToggle(item.id)}
-                aria-pressed={isActive}
-                aria-label={`${item.events.length} overlapping events`}
-              >
-                <span className="timeline__group-count">{item.events.length}</span>
-              </button>
+              <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
+                <span className="timeline__tick-line" />
+                <span className="timeline__tick-label">{tick.label}</span>
+              </div>
             );
-          }
+          })}
 
-          return (
-            <EventElement
-              key={item.event.id}
-              event={item.event}
-              leftPercent={item.leftPercent}
-              variant="main"
-              range={range}
-              now={now}
-            />
-          );
-        })}
+          {renderItems.map(item => {
+            if (item.type === "group") {
+              const isActive = activeGroup?.id === item.id;
+              return (
+                <button
+                  key={item.id}
+                  type="button"
+                  ref={node => setGroupNode(item.id, node)}
+                  className={`timeline__group ${isActive ? "timeline__group--active" : ""}`.trim()}
+                  style={{ left: `${item.leftPercent}%` }}
+                  onClick={() => handleGroupToggle(item.id)}
+                  aria-pressed={isActive}
+                  aria-label={`${item.events.length} overlapping events`}
+                >
+                  <span className="timeline__group-count">{item.events.length}</span>
+                </button>
+              );
+            }
 
-        <div
-          className="timeline__focus"
-          style={{ left: `${toPercent(valueRatio)}%` }}
-          onPointerDown={handleFocusPointerDown}
-          onPointerMove={handleFocusPointerMove}
-          onPointerUp={handleFocusPointerUp}
-          role="presentation"
-        >
-          <span className="timeline__focus-handle" />
-          <span className="timeline__focus-stem" />
+            return (
+              <EventElement
+                key={item.event.id}
+                event={item.event}
+                leftPercent={item.leftPercent}
+                variant="main"
+                range={range}
+                now={now}
+              />
+            );
+          })}
+
+          <div
+            className="timeline__focus"
+            style={{ left: `${toPercent(valueRatio)}%` }}
+            onPointerDown={handleFocusPointerDown}
+            onPointerMove={handleFocusPointerMove}
+            onPointerUp={handleFocusPointerUp}
+            role="presentation"
+          >
+            <span className="timeline__focus-handle" />
+            <span className="timeline__focus-stem" />
+          </div>
         </div>
+
+        {activeGroup && axisSize.width > 0 && (
+          <SubTimeline
+            axisWidth={axisSize.width}
+            group={activeGroup}
+            range={range}
+            onClose={handleCloseSubTimeline}
+            now={now}
+            groupElement={activeGroupNode}
+          />
+        )}
       </div>
 
-      {activeGroup && axisSize.width > 0 && (
-        <SubTimeline
-          axisWidth={axisSize.width}
-          group={activeGroup}
-          range={range}
-          onClose={handleCloseSubTimeline}
-          now={now}
-          groupElement={activeGroupNode}
-        />
-      )}
+      {valueNode && <div className="timeline__value timeline__value--below">{valueNode}</div>}
     </div>
   );
 }

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -291,19 +291,40 @@ body::before {
   margin-top: 24px;
 }
 
+.timeline-card > .subtitle {
+  align-self: center;
+  color: var(--indigo-100);
+  text-transform: uppercase;
+  letter-spacing: .14em;
+  font-size: 1.05rem;
+  font-weight: 600;
+  margin: 0 0 8px;
+  text-shadow: 0 8px 24px rgba(79, 70, 229, 0.35);
+}
+
 .timeline {
   position: relative;
   display: flex;
   flex-direction: column;
-  gap: 12px;
+  gap: 8px;
+}
+
+.timeline__stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .timeline__value {
   display: flex;
-  justify-content: space-between;
-  align-items: flex-end;
+  justify-content: flex-start;
+  align-items: flex-start;
   flex-wrap: wrap;
-  gap: 8px;
+  gap: 6px;
+}
+
+.timeline__value--below {
+  margin-top: 4px;
 }
 
 .timeline__value-content {
@@ -345,9 +366,9 @@ body::before {
 
 .timeline__axis {
   position: relative;
-  height: 260px;
-  --timeline-line-top: 58%;
-  --timeline-stripe-height: 18px;
+  height: 240px;
+  --timeline-line-top: 56%;
+  --timeline-stripe-height: 16px;
 }
 
 .timeline__line {
@@ -369,7 +390,7 @@ body::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 6px;
+  gap: 4px;
   pointer-events: none;
   z-index: 1;
 }
@@ -617,10 +638,10 @@ body::before {
 
 .timeline__subtimeline {
   position: relative;
-  margin-top: 12px;
-  padding-top: 12px;
-  padding-bottom: 28px;
-  min-height: 240px;
+  margin-top: 8px;
+  padding-top: 0;
+  padding-bottom: 20px;
+  min-height: 220px;
   --timeline-sub-gap: 72px;
 }
 
@@ -648,9 +669,9 @@ body::before {
 
 .timeline__subtimeline-axis {
   position: relative;
-  height: 160px;
-  --timeline-line-top: 72%;
-  --timeline-stripe-height: 14px;
+  height: 150px;
+  --timeline-line-top: 70%;
+  --timeline-stripe-height: 13px;
 }
 
 .timeline__subtimeline-axis .timeline__event {
@@ -664,7 +685,7 @@ body::before {
   display: flex;
   flex-direction: column;
   align-items: center;
-  gap: 4px;
+  gap: 3px;
   pointer-events: none;
   z-index: 1;
 }

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -183,7 +183,7 @@ export default function Milestones() {
 
     return (
       <div className="timeline__value-content">
-        <span className="timeline__value-label">Focus date</span>
+        <span className="timeline__value-label">Slider position</span>
         <span className="timeline__value-primary">{formatWithWeekday(instant)}</span>
         <span className="timeline__value-secondary">{relative}</span>
       </div>


### PR DESCRIPTION
## Summary
- wrap the main axis and sub-timeline in a dedicated stack so the connectors stay aligned while the slider details move beneath the timeline
- refresh the timeline card styling with a centered accent subtitle and tighter spacing across the axis, ticks and sub-timeline elements
- rename the focus details to "Slider position" and keep the information left-aligned under the timeline

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68cd9876b4fc832f882fd22e58d33004