### PR TITLE
Redesign wizard and navigation with new sections

### DIFF
--- a/src/components/BirthDateWizard.tsx
+++ b/src/components/BirthDateWizard.tsx
@@ -27,6 +27,20 @@ const STEPS = ["year", "month", "day", "hour"] as const;
 const CURRENT_YEAR = new Date().getFullYear();
 const MIN_YEAR = 1900;
 
+const STEP_LABELS: Record<(typeof STEPS)[number], string> = {
+  year: "Year",
+  month: "Month",
+  day: "Day",
+  hour: "Hour",
+};
+
+const STEP_DESCRIPTIONS: Record<(typeof STEPS)[number], string> = {
+  year: "Start with the year that marks your arrival.",
+  month: "Choose the month to narrow things down.",
+  day: "Pick the day you were born on.",
+  hour: "Add the hour if you know it, 24h format.",
+};
+
 export default function BirthDateWizard({
   initialDate,
   initialTime,
@@ -131,113 +145,176 @@ export default function BirthDateWizard({
     }
   })();
 
+  const summary = useMemo(() => {
+    const summaryMonth = typeof month === "number" ? MONTHS[month - 1] : "—";
+    const summaryDay =
+      typeof day === "number" ? day.toString().padStart(2, "0") : "—";
+    const summaryHour =
+      typeof hour === "number" ? `${hour.toString().padStart(2, "0")}:00` : "—";
+    const hasFullDate =
+      typeof year === "number" && typeof month === "number" && typeof day === "number";
+    const summaryDate = hasFullDate
+      ? new Date(year, month - 1, day).toLocaleDateString(undefined, {
+          day: "2-digit",
+          month: "long",
+          year: "numeric",
+        })
+      : "—";
+    return [
+      { label: "Year", value: typeof year === "number" ? `${year}` : "—" },
+      { label: "Month", value: summaryMonth },
+      { label: "Day", value: summaryDay },
+      { label: "Time", value: summaryHour },
+      { label: "Complete date", value: summaryDate },
+    ];
+  }, [day, hour, month, year]);
+
   return (
     <div className="birth-wizard" role="dialog" aria-modal="true" aria-labelledby={questionId}>
       <form className="birth-wizard__panel" aria-describedby={hintId} onSubmit={handleSubmit}>
-        <p className="birth-wizard__step">Step {stepIndex + 1} of {STEPS.length}</p>
-        <h2 className="birth-wizard__question" id={questionId}>
-          {step === "year" && "What year were you born?"}
-          {step === "month" && "What month?"}
-          {step === "day" && "What day?"}
-          {step === "hour" && "What time?"}
-        </h2>
+        <header className="birth-wizard__header">
+          <p className="birth-wizard__step">Step {stepIndex + 1} of {STEPS.length}</p>
+          <h2 className="birth-wizard__question" id={questionId}>
+            {step === "year" && "What year were you born?"}
+            {step === "month" && "What month?"}
+            {step === "day" && "What day?"}
+            {step === "hour" && "What time?"}
+          </h2>
+          <p className="birth-wizard__description">{STEP_DESCRIPTIONS[step]}</p>
+        </header>
 
-        <div className="birth-wizard__field">
-          {step === "year" && (
-            <input
-              type="number"
-              inputMode="numeric"
-              min={MIN_YEAR}
-              max={CURRENT_YEAR}
-              value={year}
-              onChange={event => {
-                const value = event.target.value;
-                const parsed = Number(value);
-                setYear(value === "" || Number.isNaN(parsed) ? "" : parsed);
-              }}
-              aria-describedby={hintId}
-              required
-            />
-          )}
-
-          {step === "month" && (
-            <select
-              value={month === "" ? "" : month}
-              onChange={event => {
-                const value = event.target.value;
-                setMonth(value === "" ? "" : Number(value));
-              }}
-              aria-describedby={hintId}
-              required
-            >
-              <option value="" disabled>
-                Seleziona il mese
-              </option>
-              {MONTHS.map((label, index) => (
-                <option key={label} value={index + 1}>
-                  {label}
-                </option>
+        <div className="birth-wizard__grid">
+          <aside className="birth-wizard__aside" aria-hidden="true">
+            <div className="birth-wizard__progress">
+              {STEPS.map((key, index) => (
+                <div
+                  key={key}
+                  className={`birth-wizard__progress-step ${
+                    index < stepIndex
+                      ? "birth-wizard__progress-step--done"
+                      : index === stepIndex
+                      ? "birth-wizard__progress-step--active"
+                      : ""
+                  }`}
+                >
+                  <span className="birth-wizard__progress-index">{index + 1}</span>
+                  <span className="birth-wizard__progress-label">{STEP_LABELS[key]}</span>
+                </div>
               ))}
-            </select>
-          )}
+            </div>
 
-          {step === "day" && (
-            <input
-              type="number"
-              inputMode="numeric"
-              min={1}
-              max={daysInMonth}
-              value={day}
-              onChange={event => {
-                const value = event.target.value;
-                const parsed = Number(value);
-                setDay(value === "" || Number.isNaN(parsed) ? "" : parsed);
-              }}
-              aria-describedby={hintId}
-              required
-            />
-          )}
+            <div className="birth-wizard__summary">
+              <h3 className="birth-wizard__summary-title">Current selection</h3>
+              <dl className="birth-wizard__summary-list">
+                {summary.map(item => (
+                  <div className="birth-wizard__summary-item" key={item.label}>
+                    <dt>{item.label}</dt>
+                    <dd>{item.value}</dd>
+                  </div>
+                ))}
+              </dl>
+            </div>
+          </aside>
 
-          {step === "hour" && (
-            <input
-              type="number"
-              inputMode="numeric"
-              min={0}
-              max={23}
-              value={hour}
-              onChange={event => {
-                const value = event.target.value;
-                const parsed = Number(value);
-                setHour(value === "" || Number.isNaN(parsed) ? "" : parsed);
-              }}
-              aria-describedby={hintId}
-              required
-            />
-          )}
+          <div className="birth-wizard__content">
+            <div className="birth-wizard__field">
+              {step === "year" && (
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min={MIN_YEAR}
+                  max={CURRENT_YEAR}
+                  value={year}
+                  onChange={event => {
+                    const value = event.target.value;
+                    const parsed = Number(value);
+                    setYear(value === "" || Number.isNaN(parsed) ? "" : parsed);
+                  }}
+                  aria-describedby={hintId}
+                  required
+                />
+              )}
+
+              {step === "month" && (
+                <select
+                  value={month === "" ? "" : month}
+                  onChange={event => {
+                    const value = event.target.value;
+                    setMonth(value === "" ? "" : Number(value));
+                  }}
+                  aria-describedby={hintId}
+                  required
+                >
+                  <option value="" disabled>
+                    Seleziona il mese
+                  </option>
+                  {MONTHS.map((label, index) => (
+                    <option key={label} value={index + 1}>
+                      {label}
+                    </option>
+                  ))}
+                </select>
+              )}
+
+              {step === "day" && (
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min={1}
+                  max={daysInMonth}
+                  value={day}
+                  onChange={event => {
+                    const value = event.target.value;
+                    const parsed = Number(value);
+                    setDay(value === "" || Number.isNaN(parsed) ? "" : parsed);
+                  }}
+                  aria-describedby={hintId}
+                  required
+                />
+              )}
+
+              {step === "hour" && (
+                <input
+                  type="number"
+                  inputMode="numeric"
+                  min={0}
+                  max={23}
+                  value={hour}
+                  onChange={event => {
+                    const value = event.target.value;
+                    const parsed = Number(value);
+                    setHour(value === "" || Number.isNaN(parsed) ? "" : parsed);
+                  }}
+                  aria-describedby={hintId}
+                  required
+                />
+              )}
+            </div>
+
+            <p className="birth-wizard__hint" id={hintId}>
+              {step === "day" ? `${hintText} (${monthLabel})` : hintText}
+            </p>
+
+            <div className="birth-wizard__actions">
+              <button type="button" className="birth-wizard__secondary" onClick={goBack}>
+                {stepIndex === 0 ? "Close" : "Back"}
+              </button>
+              <button type="submit" className="birth-wizard__primary" disabled={!canContinue}>
+                {isLastStep ? "Confirm data" : "Next"}
+              </button>
+            </div>
+
+            {step === "hour" && (
+              <button
+                type="button"
+                className="birth-wizard__skip"
+                onClick={() => finish(0)}
+              >
+                I dont remember (using 00:00)
+              </button>
+            )}
+          </div>
         </div>
-
-        <p className="birth-wizard__hint" id={hintId}>
-          {step === "day" ? `${hintText} (${monthLabel})` : hintText}
-        </p>
-
-        <div className="birth-wizard__actions">
-          <button type="button" className="birth-wizard__secondary" onClick={goBack}>
-            {stepIndex === 0 ? "Close" : "Back"}
-          </button>
-          <button type="submit" className="birth-wizard__primary" disabled={!canContinue}>
-            {isLastStep ? "Confirm data" : "Next"}
-          </button>
-        </div>
-
-        {step === "hour" && (
-          <button
-            type="button"
-            className="birth-wizard__skip"
-            onClick={() => finish(0)}
-          >
-            I dont remember (using 00:00)
-          </button>
-        )}
       </form>
     </div>
   );

--- a/src/components/common/Headers.tsx
+++ b/src/components/common/Headers.tsx
@@ -1,15 +1,110 @@
-import {Link} from "react-router-dom";
+import { useEffect, useId, useRef, useState } from "react";
+import { Link, useLocation } from "react-router-dom";
 
 export function Title() {
-    return (
-        <h1 className="title">AGE MILESTONES</h1>
-    )
+  return <h1 className="title">AGE MILESTONES</h1>;
 }
 
-export function Navbar() {
-    return (
-        <header className="navbar">
-            <Link to="/">← Edit date of birth</Link>
-        </header>
-    )
+const NAV_ITEMS = [
+  { to: "/", label: "Home" },
+  { to: "/milestones", label: "Milestones" },
+  { to: "/timescales", label: "Timescales" },
+  { to: "/personalize", label: "Personalize" },
+  { to: "/about", label: "About" },
+] as const;
+
+type NavbarProps = {
+  onEditBirthDate?: () => void;
+};
+
+export function Navbar({ onEditBirthDate }: NavbarProps) {
+  const [open, setOpen] = useState(false);
+  const location = useLocation();
+  const menuId = useId();
+  const menuRef = useRef<HTMLDivElement | null>(null);
+
+  useEffect(() => {
+    if (!open) return;
+    if (typeof document === "undefined") return;
+    const handleClick = (event: MouseEvent) => {
+      if (!menuRef.current) return;
+      if (!menuRef.current.contains(event.target as Node)) {
+        setOpen(false);
+      }
+    };
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") setOpen(false);
+    };
+    document.addEventListener("mousedown", handleClick);
+    document.addEventListener("keydown", handleKey);
+    return () => {
+      document.removeEventListener("mousedown", handleClick);
+      document.removeEventListener("keydown", handleKey);
+    };
+  }, [open]);
+
+  useEffect(() => {
+    setOpen(false);
+  }, [location.pathname]);
+
+  const toggle = () => setOpen(value => !value);
+  const isActive = (path: string) => {
+    if (path === "/") return location.pathname === "/";
+    return location.pathname.startsWith(path);
+  };
+
+  return (
+    <header className="app-navbar">
+      <Link to="/" className="app-navbar__brand">
+        <span className="app-navbar__brand-mark" aria-hidden="true" />
+        Age Milestones
+      </Link>
+
+      <div className="app-navbar__actions">
+        {onEditBirthDate && (
+          <button
+            type="button"
+            className="app-navbar__edit"
+            onClick={onEditBirthDate}
+          >
+            Edit birth date
+          </button>
+        )}
+
+        <div className="app-navbar__menu" ref={menuRef}>
+          <button
+            type="button"
+            className="app-navbar__menu-toggle"
+            onClick={toggle}
+            aria-haspopup="true"
+            aria-expanded={open}
+            aria-controls={`${menuId}-dropdown`}
+          >
+            <span className="app-navbar__menu-label">Menu</span>
+            <span className="app-navbar__menu-icon" aria-hidden="true" />
+          </button>
+
+          <nav
+            id={`${menuId}-dropdown`}
+            className={`app-navbar__dropdown ${
+              open ? "app-navbar__dropdown--open" : ""
+            }`}
+            aria-hidden={!open}
+          >
+            {NAV_ITEMS.map(item => (
+              <Link
+                key={item.to}
+                to={item.to}
+                className={`app-navbar__link ${
+                  isActive(item.to) ? "app-navbar__link--active" : ""
+                }`}
+              >
+                {item.label}
+              </Link>
+            ))}
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
 }

--- a/src/components/scaleOverlay.tsx
+++ b/src/components/scaleOverlay.tsx
@@ -133,14 +133,17 @@ const ScaleOverlay = ({ open, onClose, value, unit, kind }: ScaleOverlayProps) =
 
 /* ---------- Scenes ---------- */
 
-const Legend = ({ }: { text: string }) => (
-  <group position={[0, 1.15, 0]}>
-    <mesh>
-      <planeGeometry args={[2.8, 0.46]} />
-      <meshBasicMaterial color="#0e1627" transparent opacity={0.6} />
-    </mesh>
-  </group>
-);
+const Legend = ({ text }: { text: string }) => {
+  void text;
+  return (
+    <group position={[0, 1.15, 0]}>
+      <mesh>
+        <planeGeometry args={[2.8, 0.46]} />
+        <meshBasicMaterial color="#0e1627" transparent opacity={0.6} />
+      </mesh>
+    </group>
+  );
+};
 
 // numeri discreti → sfere
 const BallsScene = ({ value, unit }: SceneProps) => {

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -210,6 +210,42 @@ body::before {
 }
 .button:hover  { filter: brightness(1.1); transform: scale(.97); }
 
+.button--ghost {
+  background: transparent;
+  color: var(--indigo-100);
+  border: 1px solid rgba(165, 180, 252, 0.5);
+  box-shadow: 0 10px 24px rgba(79, 70, 229, 0.25);
+}
+
+.button--ghost:hover {
+  filter: none;
+  transform: translateY(-1px);
+  background: rgba(79, 70, 229, 0.15);
+}
+
+.landing__buttons {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  width: 100%;
+}
+
+.landing__buttons .button {
+  margin-top: 0;
+  width: 100%;
+}
+
+@media (min-width: 560px) {
+  .landing__buttons {
+    flex-direction: row;
+    justify-content: center;
+  }
+
+  .landing__buttons .button {
+    width: auto;
+  }
+}
+
 .more-btn {
   margin-top: 16px;
   background: var(--slate-700);
@@ -727,18 +763,219 @@ body::before {
   .timeline__value-primary { font-size: 1.3rem; }
 }
 
-/* -----------------------------------------------------------
-   9.  Navbar & footer
------------------------------------------------------------ */
-.navbar {
-  width: 100%;
-  display: flex;
-  justify-content: flex-start;
-  padding: 0 clamp(8px, 2vw, 16px);
-  box-sizing: border-box;
-}
-.navbar a { color: var(--indigo-100); text-decoration: none; }
-.navbar a:hover { text-decoration: underline; }
+  /* -----------------------------------------------------------
+     9.  Navbar & footer
+  ----------------------------------------------------------- */
+  .app-navbar {
+    width: 100%;
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 16px;
+    padding: clamp(12px, 2.5vw, 20px) clamp(16px, 3vw, 28px);
+    background: rgba(15, 23, 42, 0.55);
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    border-radius: 24px;
+    box-shadow: 0 26px 48px rgba(15, 23, 42, 0.45);
+    backdrop-filter: blur(18px);
+  }
+
+  .app-navbar__brand {
+    display: inline-flex;
+    align-items: center;
+    gap: 12px;
+    text-decoration: none;
+    font-size: .95rem;
+    letter-spacing: .12em;
+    font-weight: 700;
+    text-transform: uppercase;
+    color: var(--text-light);
+  }
+
+  .app-navbar__brand-mark {
+    width: 14px;
+    height: 14px;
+    border-radius: 999px;
+    background: linear-gradient(135deg, #38bdf8, var(--indigo-300));
+    box-shadow: 0 0 12px rgba(56, 189, 248, 0.65);
+  }
+
+  .app-navbar__actions {
+    display: flex;
+    align-items: center;
+    gap: 12px;
+  }
+
+  .app-navbar__edit {
+    padding: 10px 20px;
+    border-radius: 999px;
+    border: 1px solid rgba(129, 140, 248, 0.6);
+    background: linear-gradient(120deg, rgba(79, 70, 229, 0.85), rgba(129, 140, 248, 0.8));
+    color: #fff;
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 18px 32px rgba(79, 70, 229, 0.45);
+    transition: transform .15s ease, box-shadow .15s ease;
+  }
+
+  .app-navbar__edit:hover {
+    transform: translateY(-1px);
+    box-shadow: 0 22px 40px rgba(79, 70, 229, 0.55);
+  }
+
+  .app-navbar__menu {
+    position: relative;
+    display: flex;
+    align-items: center;
+  }
+
+  .app-navbar__menu-toggle {
+    display: inline-flex;
+    align-items: center;
+    gap: 10px;
+    padding: 10px 16px;
+    border-radius: 999px;
+    border: 1px solid rgba(148, 163, 184, 0.45);
+    background: rgba(17, 24, 39, 0.65);
+    color: var(--text-light);
+    font-weight: 600;
+    cursor: pointer;
+    box-shadow: 0 12px 24px rgba(15, 23, 42, 0.45);
+    transition: transform .15s ease, box-shadow .15s ease, background .15s ease;
+  }
+
+  .app-navbar__menu-toggle:hover {
+    transform: translateY(-1px);
+    background: rgba(31, 41, 55, 0.75);
+  }
+
+  .app-navbar__menu-label {
+    font-size: .85rem;
+    letter-spacing: .08em;
+    text-transform: uppercase;
+  }
+
+  .app-navbar__menu-icon {
+    position: relative;
+    width: 18px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    display: inline-flex;
+  }
+
+  .app-navbar__menu-icon::before,
+  .app-navbar__menu-icon::after {
+    content: "";
+    position: absolute;
+    left: 0;
+    width: 18px;
+    height: 2px;
+    border-radius: 999px;
+    background: currentColor;
+    transition: transform .2s ease, opacity .2s ease;
+  }
+
+  .app-navbar__menu-icon::before { top: -6px; }
+  .app-navbar__menu-icon::after  { top:  6px; }
+
+  .app-navbar__menu-toggle[aria-expanded="true"] .app-navbar__menu-icon {
+    background: transparent;
+  }
+
+  .app-navbar__menu-toggle[aria-expanded="true"] .app-navbar__menu-icon::before {
+    transform: translateY(6px) rotate(45deg);
+  }
+
+  .app-navbar__menu-toggle[aria-expanded="true"] .app-navbar__menu-icon::after {
+    transform: translateY(-6px) rotate(-45deg);
+  }
+
+  .app-navbar__dropdown {
+    position: absolute;
+    top: calc(100% + 12px);
+    right: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 8px;
+    padding: 18px;
+    min-width: 200px;
+    border-radius: 20px;
+    background: rgba(15, 23, 42, 0.88);
+    border: 1px solid rgba(129, 140, 248, 0.35);
+    box-shadow: 0 26px 48px rgba(15, 23, 42, 0.55);
+    backdrop-filter: blur(18px);
+    opacity: 0;
+    pointer-events: none;
+    transform: translateY(-10px);
+    transition: opacity .2s ease, transform .2s ease;
+    z-index: 10;
+  }
+
+  .app-navbar__dropdown--open {
+    opacity: 1;
+    pointer-events: auto;
+    transform: translateY(0);
+  }
+
+  .app-navbar__link {
+    text-decoration: none;
+    color: var(--text-light);
+    font-weight: 500;
+    padding: 10px 12px;
+    border-radius: 12px;
+    transition: background .15s ease, color .15s ease;
+  }
+
+  .app-navbar__link:hover {
+    background: rgba(129, 140, 248, 0.2);
+  }
+
+  .app-navbar__link--active {
+    background: linear-gradient(120deg, rgba(99, 102, 241, 0.6), rgba(129, 140, 248, 0.6));
+    color: #fff;
+    box-shadow: 0 12px 28px rgba(99, 102, 241, 0.45);
+  }
+
+  @media (max-width: 640px) {
+    .app-navbar {
+      flex-direction: column;
+      align-items: stretch;
+      gap: 12px;
+    }
+
+    .app-navbar__actions {
+      justify-content: space-between;
+      width: 100%;
+      gap: 10px;
+    }
+
+    .app-navbar__edit {
+      flex: 1;
+      text-align: center;
+      padding: 10px 14px;
+    }
+
+    .app-navbar__menu {
+      justify-content: flex-end;
+    }
+  }
+
+  @media (max-width: 420px) {
+    .app-navbar__actions {
+      flex-direction: column;
+      align-items: stretch;
+    }
+
+    .app-navbar__menu {
+      width: 100%;
+    }
+
+    .app-navbar__menu-toggle {
+      width: 100%;
+      justify-content: center;
+    }
+  }
 
 .footer {
   width: 100%;
@@ -772,72 +1009,242 @@ body::before {
 ----------------------------------------------------------- */
 .tabs {
   display: flex;
-  flex-wrap: wrap;               /* allow multiple lines on very narrow screens */
+  flex-wrap: wrap;
   justify-content: center;
   align-items: center;
-  gap: 0px;                     /* more breathing room */
-  margin-bottom: 24px;           /* spacing below the tabs */
+  gap: 12px;
 }
 
 .tab {
-  padding: 8px 16px;
-  border: 1px solid var(--slate-700);
-  border-radius: 1px;
-  background: var(--slate-900);
+  padding: 10px 22px;
+  border-radius: 999px;
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  background: rgba(17, 24, 39, 0.55);
   color: var(--text-light);
-  font-size: 0.9rem;
-  font-weight: 500;
+  font-size: .95rem;
+  font-weight: 600;
+  letter-spacing: .03em;
   cursor: pointer;
-  transition: background 0.2s, border-color 0.2s, color 0.2s;
+  backdrop-filter: blur(12px);
+  box-shadow: 0 14px 26px rgba(15, 23, 42, 0.4);
+  transition: transform .15s ease, box-shadow .15s ease, background .2s ease;
 }
 
 .tab:hover {
-  background: var(--slate-800);
+  transform: translateY(-2px);
+  background: rgba(30, 41, 59, 0.65);
+}
+
+.tab:focus-visible {
+  outline: 2px solid rgba(129, 140, 248, 0.5);
+  outline-offset: 2px;
 }
 
 .tab--active {
-  background: var(--indigo-600) !important;
-  border-color: var(--indigo-600) !important;
-  color: #fff !important;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(129, 140, 248, 0.8));
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 20px 38px rgba(79, 70, 229, 0.45);
+  transform: translateY(-2px);
 }
-.table-wrap {
+
+.age-table {
+  width: min(540px, 100%);
+  margin: 0 auto;
+  border-collapse: collapse;
+  font-variant-numeric: tabular-nums;
+  overflow: hidden;
+  border-radius: 22px;
+  background: rgba(15, 23, 42, 0.45);
+  border: 1px solid rgba(129, 140, 248, 0.25);
+  box-shadow: 0 28px 48px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(18px);
+}
+
+.age-table tr:nth-child(odd)  { background: rgba(15, 23, 42, 0.55); }
+.age-table tr:nth-child(even) { background: rgba(30, 41, 59, 0.45); }
+
+.age-table td {
+  padding: 14px clamp(18px, 4vw, 32px);
+}
+
+.age-table td:first-child {
+  color: var(--text-muted);
+  font-weight: 500;
+  text-align: left;
+}
+
+.age-table .age-val {
+  color: var(--text-light);
+  text-align: right;
+  font-weight: 600;
+  position: relative;
+  transition: color .3s ease;
+  word-break: break-word;
+}
+
+.age-table .age-val::after {
+  content: "";
+  position: absolute;
+  inset: 0;
+  background: radial-gradient(ellipse at center, rgba(0, 227, 255, 0.35) 0%, transparent 70%);
+  opacity: 0;
+  transition: opacity .3s ease;
+}
+
+.age-table .age-val.updated {
+  color: var(--indigo-100);
+}
+
+.age-table .age-val.updated::after {
+  opacity: 1;
+}
+
+/* -----------------------------------------------------------
+   12.  Perspective card & mock sections
+----------------------------------------------------------- */
+.perspective-card {
   width: 100%;
   display: flex;
   flex-direction: column;
+  gap: clamp(20px, 3vw, 30px);
+  padding: clamp(24px, 4vw, 36px);
+  border-radius: 32px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  box-shadow: 0 34px 68px rgba(15, 23, 42, 0.45);
+  backdrop-filter: blur(20px);
+}
+
+.perspective-card__body {
+  display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 16px;
-  overflow-x: auto;      /* allow sideways scroll for huge values */
-  padding-bottom: 8px;
-  margin-bottom: 24px;    /* spacing below the table */
-}
-.table-wrap .subtitle {
+  gap: 18px;
   text-align: center;
+}
+
+.perspective-card__title {
   margin: 0;
+  font-size: clamp(1.45rem, 3vw, 2.1rem);
+  font-weight: 700;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-light);
 }
-.age-table {
-  width: min(520px, 100%);
-  margin: 0 auto 28px;
-  border-collapse: collapse; font-variant-numeric: tabular-nums;
-  overflow: hidden; border-radius: 12px; box-shadow: 0 12px 24px rgba(0,0,0,.35);
-}
-.age-table tr:nth-child(odd)  { background: #243447; }
-.age-table tr:nth-child(even) { background: #1d2b3a; }
 
-.age-table td { padding: 10px clamp(16px, 4vw, 28px); }
-.age-table tr:last-child td { border-bottom: none; }
+.perspective-card__title-accent {
+  color: var(--indigo-100);
+  text-transform: capitalize;
+}
 
-.age-table td:first-child { color: var(--text-muted); font-weight: 500; }
-.age-table .age-val {
-  color: var(--text-light); text-align: right; font-weight: 600;
-  position: relative; transition: color .3s; word-break: break-all;
+.perspective-card__subtitle {
+  margin: 0;
+  font-size: .95rem;
+  color: var(--text-muted);
+  max-width: 36ch;
 }
-.age-table .age-val::after {
-  content: ""; position: absolute; inset: 0;
-  background: radial-gradient(ellipse at center, rgba(0,227,255,.35) 0%, transparent 70%);
-  opacity: 0; transition: opacity .3s;
+
+.perspective-card__table {
+  width: 100%;
+  display: flex;
+  justify-content: center;
 }
-.age-table .age-val.updated { color: var(--indigo-100); }
-.age-table .age-val.updated::after { opacity: 1; }
+
+.section-grid {
+  width: 100%;
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(240px, 1fr));
+  gap: clamp(18px, 3vw, 28px);
+}
+
+.section-card {
+  padding: clamp(20px, 3vw, 28px);
+  border-radius: 28px;
+  background: rgba(15, 23, 42, 0.55);
+  border: 1px solid rgba(129, 140, 248, 0.3);
+  box-shadow: 0 28px 58px rgba(15, 23, 42, 0.45);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  backdrop-filter: blur(18px);
+}
+
+.section-card__title {
+  margin: 0;
+  font-size: 1.15rem;
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+.section-card__text {
+  margin: 0;
+  color: var(--text-muted);
+  font-size: .95rem;
+  line-height: 1.6;
+}
+
+.section-card__list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
+.section-card__list li {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  color: var(--text-light);
+}
+
+.section-card__bullet {
+  width: 8px;
+  height: 8px;
+  border-radius: 999px;
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.85), rgba(129, 140, 248, 0.8));
+  box-shadow: 0 0 12px rgba(129, 140, 248, 0.6);
+}
+
+.section-card__preview {
+  height: 120px;
+  border-radius: 20px;
+  border: 1px dashed rgba(129, 140, 248, 0.4);
+  background: rgba(17, 24, 39, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  color: var(--text-muted);
+  font-size: .85rem;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+}
+
+.section-card__chips {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 10px;
+}
+
+.section-card__chip {
+  padding: 6px 12px;
+  border-radius: 999px;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  color: var(--indigo-100);
+  font-size: .8rem;
+  letter-spacing: .05em;
+  text-transform: uppercase;
+  background: rgba(17, 24, 39, 0.45);
+}
+
+@media (max-width: 720px) {
+  .perspective-card {
+    padding: 24px;
+    border-radius: 26px;
+  }
+}
 
 /* -----------------------------------------------------------
    9. Landing wizard overlay
@@ -887,21 +1294,28 @@ body::before {
 }
 
 .birth-wizard__panel {
-  width: min(520px, 92vw);
-  background: linear-gradient(145deg, #0f1a31 0%, #15294a 100%);
-  border-radius: 20px;
-  padding: 32px;
-  box-shadow: 0 20px 60px rgba(0, 0, 0, 0.55);
-  border: 1px solid rgba(79, 70, 229, 0.35);
+  width: min(760px, 94vw);
+  background: linear-gradient(145deg, rgba(15, 24, 44, 0.95), rgba(28, 41, 72, 0.92));
+  border-radius: 32px;
+  padding: clamp(28px, 4vw, 36px);
+  box-shadow: 0 34px 72px rgba(6, 11, 25, 0.65);
+  border: 1px solid rgba(129, 140, 248, 0.45);
   display: flex;
   flex-direction: column;
-  gap: 24px;
+  gap: clamp(20px, 3vw, 28px);
+  backdrop-filter: blur(18px);
+}
+
+.birth-wizard__header {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
 }
 
 .birth-wizard__step {
   margin: 0;
-  letter-spacing: 0.08em;
-  font-size: 0.85rem;
+  letter-spacing: .1em;
+  font-size: .85rem;
   text-transform: uppercase;
   color: var(--text-muted);
 }
@@ -909,25 +1323,167 @@ body::before {
 .birth-wizard__question {
   margin: 0;
   font-family: "Audiowide", system-ui, sans-serif;
-  font-size: clamp(1.6rem, 3vw, 2rem);
+  font-size: clamp(1.7rem, 3.2vw, 2.15rem);
   color: var(--text-light);
+  letter-spacing: .02em;
 }
 
-.birth-wizard__field {
+.birth-wizard__description {
+  margin: 0;
+  color: var(--indigo-100);
+  font-size: .95rem;
+  letter-spacing: .02em;
+}
+
+.birth-wizard__grid {
+  display: grid;
+  grid-template-columns: minmax(0, 0.95fr) minmax(0, 1.2fr);
+  gap: clamp(20px, 3vw, 28px);
+  align-items: stretch;
+}
+
+.birth-wizard__aside {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+  padding: clamp(18px, 2.5vw, 24px);
+  border-radius: 24px;
+  background: rgba(12, 19, 36, 0.6);
+  border: 1px solid rgba(129, 140, 248, 0.25);
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.18);
+}
+
+.birth-wizard__progress {
   display: flex;
   flex-direction: column;
   gap: 12px;
 }
 
+.birth-wizard__progress-step {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+  padding: 10px 12px;
+  border-radius: 16px;
+  border: 1px solid rgba(129, 140, 248, 0.18);
+  background: rgba(11, 17, 31, 0.55);
+  color: var(--text-muted);
+  transition: background .2s ease, box-shadow .2s ease, color .2s ease;
+}
+
+.birth-wizard__progress-step--active {
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.7), rgba(129, 140, 248, 0.68));
+  border-color: transparent;
+  color: #fff;
+  box-shadow: 0 20px 38px rgba(79, 70, 229, 0.4);
+}
+
+.birth-wizard__progress-step--done {
+  background: rgba(79, 70, 229, 0.25);
+  border-color: rgba(129, 140, 248, 0.35);
+  color: var(--indigo-100);
+}
+
+.birth-wizard__progress-index {
+  width: 28px;
+  height: 28px;
+  border-radius: 999px;
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  background: rgba(129, 140, 248, 0.28);
+  color: var(--text-light);
+  font-weight: 600;
+  font-size: .9rem;
+}
+
+.birth-wizard__progress-step--active .birth-wizard__progress-index {
+  background: rgba(17, 24, 39, 0.2);
+}
+
+.birth-wizard__progress-step--done .birth-wizard__progress-index {
+  background: rgba(79, 70, 229, 0.3);
+  color: var(--indigo-100);
+}
+
+.birth-wizard__progress-label {
+  font-size: .9rem;
+  letter-spacing: .03em;
+  text-transform: capitalize;
+}
+
+.birth-wizard__summary {
+  display: flex;
+  flex-direction: column;
+  gap: 12px;
+  padding: 16px;
+  border-radius: 20px;
+  background: rgba(17, 24, 39, 0.55);
+  border: 1px dashed rgba(129, 140, 248, 0.45);
+}
+
+.birth-wizard__summary-title {
+  margin: 0;
+  font-size: .8rem;
+  text-transform: uppercase;
+  letter-spacing: .12em;
+  color: var(--indigo-100);
+}
+
+.birth-wizard__summary-list {
+  margin: 0;
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px;
+}
+
+.birth-wizard__summary-item {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.birth-wizard__summary-item dt {
+  margin: 0;
+  font-size: .72rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.birth-wizard__summary-item dd {
+  margin: 0;
+  color: var(--text-light);
+  font-weight: 600;
+}
+
+.birth-wizard__content {
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+  padding: clamp(20px, 3vw, 26px);
+  border-radius: 24px;
+  background: rgba(17, 24, 39, 0.6);
+  border: 1px solid rgba(129, 140, 248, 0.28);
+  box-shadow: 0 24px 46px rgba(15, 23, 42, 0.45);
+}
+
+.birth-wizard__field {
+  display: flex;
+  flex-direction: column;
+  gap: 14px;
+}
+
 .birth-wizard__field input,
 .birth-wizard__field select {
-  font-size: 1.1rem;
-  padding: 12px;
-  border-radius: 14px;
-  border: 1px solid var(--slate-700);
-  background: rgba(17, 24, 39, 0.85);
+  font-size: 1.3rem;
+  padding: 16px;
+  border-radius: 18px;
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  background: rgba(6, 11, 25, 0.55);
   color: var(--text-light);
   text-align: center;
+  box-shadow: inset 0 0 0 1px rgba(79, 70, 229, 0.25);
 }
 
 .birth-wizard__field select {
@@ -936,75 +1492,94 @@ body::before {
 
 .birth-wizard__hint {
   margin: 0;
-  font-size: 0.9rem;
+  font-size: .9rem;
   color: var(--text-muted);
 }
 
 .birth-wizard__actions {
   display: flex;
-  gap: 12px;
   flex-wrap: wrap;
+  gap: 12px;
 }
 
 .birth-wizard__actions button {
   flex: 1;
-  min-width: 140px;
-  padding: 12px 20px;
+  min-width: 150px;
+  padding: 14px 22px;
   border-radius: 999px;
   border: none;
   font-weight: 600;
   cursor: pointer;
-  transition: transform 0.15s ease, filter 0.15s ease;
+  transition: transform .15s ease, box-shadow .15s ease, filter .15s ease;
 }
 
 .birth-wizard__actions button:disabled {
-  opacity: 0.6;
+  opacity: .6;
   cursor: not-allowed;
 }
 
 .birth-wizard__primary {
-  background: var(--indigo-600);
+  background: linear-gradient(135deg, rgba(79, 70, 229, 0.95), rgba(129, 140, 248, 0.92));
   color: #fff;
+  box-shadow: 0 18px 36px rgba(79, 70, 229, 0.45);
 }
 
 .birth-wizard__primary:hover {
-  filter: brightness(1.1);
-  transform: scale(0.97);
+  transform: translateY(-1px);
+  filter: brightness(1.05);
 }
 
 .birth-wizard__secondary {
-  background: rgba(148, 163, 184, 0.18);
+  background: rgba(148, 163, 184, 0.16);
   color: var(--text-light);
   border: 1px solid rgba(148, 163, 184, 0.35);
 }
 
 .birth-wizard__secondary:hover {
-  background: rgba(148, 163, 184, 0.28);
+  background: rgba(148, 163, 184, 0.25);
 }
 
 .birth-wizard__skip {
   width: 100%;
-  padding: 12px 20px;
+  padding: 12px 22px;
   border-radius: 999px;
-  border: 1px dashed rgba(129, 140, 248, 0.55);
-  background: rgba(79, 70, 229, 0.2);
+  border: 1px dashed rgba(129, 140, 248, 0.6);
+  background: rgba(79, 70, 229, 0.18);
   color: var(--text-light);
   font-weight: 600;
   cursor: pointer;
-  transition: filter 0.15s ease, transform 0.15s ease;
+  transition: transform .15s ease, filter .15s ease;
 }
 
 .birth-wizard__skip:hover {
-  filter: brightness(1.1);
-  transform: scale(0.99);
+  transform: translateY(-1px);
+  filter: brightness(1.05);
 }
 
-@media (max-width: 520px) {
+@media (max-width: 720px) {
+  .birth-wizard__grid {
+    grid-template-columns: 1fr;
+  }
+
+  .birth-wizard__aside {
+    order: 2;
+  }
+
+  .birth-wizard__content {
+    order: 1;
+  }
+}
+
+@media (max-width: 560px) {
   .birth-wizard__panel {
-    padding: 28px 24px;
+    padding: 24px 20px;
+  }
+
+  .birth-wizard__summary-list {
+    grid-template-columns: 1fr;
   }
 
   .birth-wizard__actions button {
-    min-width: 120px;
+    min-width: 130px;
   }
 }

--- a/src/hooks/useBirthWizard.ts
+++ b/src/hooks/useBirthWizard.ts
@@ -1,0 +1,37 @@
+import { useCallback, useEffect, useState } from "react";
+import { useBirthDate } from "../context/BirthDateContext";
+
+export function useBirthWizard() {
+  const { birthDate, setBirthDate, birthTime, setBirthTime } = useBirthDate();
+  const [isOpen, setIsOpen] = useState(false);
+
+  const openWizard = useCallback(() => setIsOpen(true), []);
+  const closeWizard = useCallback(() => setIsOpen(false), []);
+
+  const completeWizard = useCallback(
+    (date: Date, time: string) => {
+      setBirthDate(date);
+      setBirthTime(time);
+      setIsOpen(false);
+    },
+    [setBirthDate, setBirthTime],
+  );
+
+  useEffect(() => {
+    if (!isOpen || typeof document === "undefined") return;
+    const { overflow } = document.body.style;
+    document.body.style.overflow = "hidden";
+    return () => {
+      document.body.style.overflow = overflow;
+    };
+  }, [isOpen]);
+
+  return {
+    birthDate,
+    birthTime,
+    isOpen,
+    openWizard,
+    closeWizard,
+    completeWizard,
+  };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -7,6 +7,9 @@ import "./css/index.css";
 import { BirthDateProvider } from "./context/BirthDateContext";
 import Landing from "./pages/Landing";
 import Milestones from "./pages/Milestones";
+import Timescales from "./pages/Timescales";
+import Personalize from "./pages/Personalize";
+import About from "./pages/About";
 
 
 createRoot(document.getElementById("root")!).render(
@@ -14,8 +17,11 @@ createRoot(document.getElementById("root")!).render(
     <BirthDateProvider>
       <BrowserRouter>
         <Routes>
-          <Route path="/" element={<Landing/>}/>
-          <Route path="/milestones" element={<Milestones/>}/>
+          <Route path="/" element={<Landing />} />
+          <Route path="/milestones" element={<Milestones />} />
+          <Route path="/timescales" element={<Timescales />} />
+          <Route path="/personalize" element={<Personalize />} />
+          <Route path="/about" element={<About />} />
         </Routes>
       </BrowserRouter>
       <Analytics />

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,0 +1,53 @@
+import BirthDateWizard from "../components/BirthDateWizard";
+import Footer from "../components/common/Footer";
+import { Navbar, Title } from "../components/common/Headers";
+import { useBirthWizard } from "../hooks/useBirthWizard";
+
+export default function About() {
+  const { birthDate, birthTime, isOpen, openWizard, closeWizard, completeWizard } = useBirthWizard();
+
+  return (
+    <>
+      <Navbar onEditBirthDate={openWizard} />
+      <main className="page">
+        <Title />
+        <section className="section-grid">
+          <article className="section-card">
+            <h2 className="section-card__title">Our mission</h2>
+            <p className="section-card__text">
+              Age Milestones is being designed as a calm companion that reframes time. By blending scientific
+              references with poetic storytelling we hope to help you feel grounded, inspired, and curious about
+              every chapter ahead.
+            </p>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">Built with curiosity</h2>
+            <p className="section-card__text">
+              The project is crafted in Florence by Niccolò Mei Innocenti. This space will later include a short
+              bio, credits, and behind-the-scenes notes about the tools used to bring each visualization to life.
+            </p>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">What&apos;s coming</h2>
+            <p className="section-card__text">
+              Expect deep dives on how perspectives are calculated, transparency about data usage, and links to
+              further readings. If you have suggestions, the upcoming feedback form will be the best way to reach out.
+            </p>
+          </article>
+        </section>
+      </main>
+      <Footer />
+
+      {isOpen && (
+        <BirthDateWizard
+          initialDate={birthDate}
+          initialTime={birthTime}
+          onCancel={closeWizard}
+          onComplete={completeWizard}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/Personalize.tsx
+++ b/src/pages/Personalize.tsx
@@ -1,0 +1,64 @@
+import BirthDateWizard from "../components/BirthDateWizard";
+import Footer from "../components/common/Footer";
+import { Navbar, Title } from "../components/common/Headers";
+import { useBirthWizard } from "../hooks/useBirthWizard";
+
+export default function Personalize() {
+  const { birthDate, birthTime, isOpen, openWizard, closeWizard, completeWizard } = useBirthWizard();
+
+  return (
+    <>
+      <Navbar onEditBirthDate={openWizard} />
+      <main className="page">
+        <Title />
+        <section className="section-grid">
+          <article className="section-card">
+            <h2 className="section-card__title">Tailor your journey</h2>
+            <p className="section-card__text">
+              The personalization hub will let you name milestones, pick iconography, and apply themes that
+              reflect your story. Imagine toggles for night mode, typography, and mindful focus modes.
+            </p>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">Signature palette</h2>
+            <div className="section-card__chips">
+              <span className="section-card__chip">Neon dusk</span>
+              <span className="section-card__chip">Aurora</span>
+              <span className="section-card__chip">Minimal</span>
+            </div>
+            <p className="section-card__text">
+              Themes will adapt backgrounds, gradients, and typographic tone so the experience always feels
+              personal.
+            </p>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">Focus presets</h2>
+            <ul className="section-card__list">
+              <li>
+                <span className="section-card__bullet" />Career checkpoints
+              </li>
+              <li>
+                <span className="section-card__bullet" />Family and relationships
+              </li>
+              <li>
+                <span className="section-card__bullet" />Health and mindfulness streaks
+              </li>
+            </ul>
+          </article>
+        </section>
+      </main>
+      <Footer />
+
+      {isOpen && (
+        <BirthDateWizard
+          initialDate={birthDate}
+          initialTime={birthTime}
+          onCancel={closeWizard}
+          onComplete={completeWizard}
+        />
+      )}
+    </>
+  );
+}

--- a/src/pages/Timescales.tsx
+++ b/src/pages/Timescales.tsx
@@ -1,0 +1,69 @@
+import BirthDateWizard from "../components/BirthDateWizard";
+import Footer from "../components/common/Footer";
+import { Navbar, Title } from "../components/common/Headers";
+import { useBirthWizard } from "../hooks/useBirthWizard";
+
+export default function Timescales() {
+  const { birthDate, birthTime, isOpen, openWizard, closeWizard, completeWizard } = useBirthWizard();
+
+  return (
+    <>
+      <Navbar onEditBirthDate={openWizard} />
+      <main className="page">
+        <Title />
+        <section className="section-grid">
+          <article className="section-card">
+            <h2 className="section-card__title">Layered timescales</h2>
+            <p className="section-card__text">
+              Preview how your life aligns with cosmic, cultural, and biological clocks. Each block will
+              become an interactive lens that recalculates your milestones on the fly.
+            </p>
+            <ul className="section-card__list">
+              <li>
+                <span className="section-card__bullet" />Solar cycles and equinox rhythms
+              </li>
+              <li>
+                <span className="section-card__bullet" />Planetary orbits compared side by side
+              </li>
+              <li>
+                <span className="section-card__bullet" />Meaningful anniversaries auto-detected
+              </li>
+            </ul>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">Timeline preview</h2>
+            <div className="section-card__preview">Interactive mock timeline</div>
+            <p className="section-card__text">
+              Drag through decades, zoom into months, and reveal hidden events generated from your birth data.
+              Tooltips and contextual hints will help make sense of every tick.
+            </p>
+            <div className="section-card__chips">
+              <span className="section-card__chip">Daily</span>
+              <span className="section-card__chip">Seasonal</span>
+              <span className="section-card__chip">Deep time</span>
+            </div>
+          </article>
+
+          <article className="section-card">
+            <h2 className="section-card__title">What&apos;s next</h2>
+            <p className="section-card__text">
+              This area will soon host widgets that let you bookmark key checkpoints, compare them with friends,
+              and export custom countdowns.
+            </p>
+          </article>
+        </section>
+      </main>
+      <Footer />
+
+      {isOpen && (
+        <BirthDateWizard
+          initialDate={birthDate}
+          initialTime={birthTime}
+          onCancel={closeWizard}
+          onComplete={completeWizard}
+        />
+      )}
+    </>
+  );
+}


### PR DESCRIPTION
## Summary
- refactor the birth date wizard with a guided stepper, live summary, and a reusable hook for opening the modal in any page
- replace the milestones navigation with a frosted dropdown bar, add a saved-date shortcut on the landing page, and restyle the perspectives table
- add placeholder Timescales, Personalize, and About pages with matching glassmorphism cards and share the navigation across sections

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cec537a308832f9e5d84c0b1964e26