### PR TITLE
Simplify scale overlay and placeholders

### DIFF
--- a/src/components/common/MockCard.tsx
+++ b/src/components/common/MockCard.tsx
@@ -1,0 +1,17 @@
+import type { ReactNode } from "react";
+
+const DEFAULT_LABEL = "Mock";
+
+type MockCardProps = {
+  label?: ReactNode;
+};
+
+export function MockCard({ label = DEFAULT_LABEL }: MockCardProps) {
+  return (
+    <article className="section-card section-card--mock" aria-label="Mock section">
+      <div className="section-card__mock-label">{label}</div>
+    </article>
+  );
+}
+
+export default MockCard;

--- a/src/components/common/scaleHint.tsx
+++ b/src/components/common/scaleHint.tsx
@@ -1,17 +1,33 @@
 import { ButHowMuch, type ScaleKind } from "../scaleOverlay";
 
-type HowMuchHintProps = { value: number; unit?: string; kind: ScaleKind };
+type HowMuchHintProps = {
+  value: number;
+  unit?: string;
+  kind: ScaleKind;
+  disabled?: boolean;
+};
 
-export const HowMuchHint = ({ value, unit, kind }: HowMuchHintProps) => (
-  <ButHowMuch value={value} unit={unit} kind={kind}>
-    <button
-      type="button"
-      className="howmuch-btn"
-      title="But how much is it?"
-      aria-label="But how much is it?"
-      style={{ pointerEvents: "auto", position: "relative", zIndex: 10 }}
-    >
-      ?
-    </button>
-  </ButHowMuch>
-);
+const MIN_INTERESTING_VALUE = 0.001;
+const MAX_INTERESTING_VALUE = 1000;
+
+export const HowMuchHint = ({ value, unit, kind, disabled = false }: HowMuchHintProps) => {
+  const magnitude = Math.abs(value);
+  const hideByMagnitude =
+    magnitude >= MIN_INTERESTING_VALUE && magnitude <= MAX_INTERESTING_VALUE;
+  if (disabled || hideByMagnitude || Number.isNaN(value) || kind !== "count") {
+    return null;
+  }
+
+  return (
+    <ButHowMuch value={value} unit={unit} kind={kind}>
+      <button
+        type="button"
+        className="howmuch-btn"
+        title="But how much is it?"
+        aria-label="But how much is it?"
+      >
+        ?
+      </button>
+    </ButHowMuch>
+  );
+};

--- a/src/components/scaleOverlay.tsx
+++ b/src/components/scaleOverlay.tsx
@@ -1,16 +1,11 @@
-// components/scaleOverlay.tsx
 "use client";
 
-import type { JSX, ReactNode, MouseEvent } from "react";
+import { useEffect, useMemo, useRef, useState, type MouseEvent, type ReactNode } from "react";
 import { createPortal } from "react-dom";
-import { Canvas } from "@react-three/fiber";
-import { Environment, OrbitControls, Html } from "@react-three/drei";
-import { Physics, InstancedRigidBodies, RigidBody } from "@react-three/rapier";
-import { motion, AnimatePresence } from "framer-motion";
-import { useMemo, useState } from "react";
-import { pickStep, buildEquivalents } from "../utils/scaleConstants";
+import { AnimatePresence, motion } from "framer-motion";
 
-/* ---------- tipi di base ---------- */
+import { buildEquivalents, pickStep } from "../utils/scaleConstants";
+import { formatBig } from "../utils/format";
 
 export type ScaleKind =
   | "count"
@@ -35,249 +30,210 @@ type ScaleOverlayProps = {
   kind: ScaleKind;
 };
 
-type SceneProps = { value: number; unit?: string };
+const MAX_DOTS = 360;
+const mediumFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 1 });
+const smallFormatter = new Intl.NumberFormat(undefined, { maximumFractionDigits: 3 });
 
-type InstanceDesc = {
-  key: string;
-  position: [number, number, number];
-  rotation: [number, number, number];
+const formatCount = (value: number) => {
+  if (!Number.isFinite(value)) return "—";
+  const abs = Math.abs(value);
+  if (abs >= 1_000_000) return formatBig(value);
+  if (abs >= 1_000) return Math.round(value).toLocaleString();
+  if (abs >= 1) return mediumFormatter.format(value);
+  return smallFormatter.format(value);
 };
 
-/* Toggle per debug: se Rapier non parte, metti false e vedrai comunque le sfere */
-const ENABLE_PHYSICS = true;
+const formatLegend = (value: number, unit?: string) => {
+  if (!Number.isFinite(value)) return unit ?? "1";
+  const abs = Math.abs(value);
+  let maximumFractionDigits = 0;
+  if (abs < 0.001) maximumFractionDigits = 6;
+  else if (abs < 0.01) maximumFractionDigits = 4;
+  else if (abs < 1) maximumFractionDigits = 3;
+  else if (abs < 10) maximumFractionDigits = 2;
+  const formatter = new Intl.NumberFormat(undefined, { maximumFractionDigits });
+  const base = formatter.format(value);
+  return unit ? `${base} ${unit}` : base;
+};
 
-/* ---------- trigger + overlay ---------- */
+const useAnimatedNumber = (target: number, active: boolean, duration = 700) => {
+  const [display, setDisplay] = useState(target);
+  const fromRef = useRef(target);
+
+  useEffect(() => {
+    if (!active) {
+      fromRef.current = target;
+      setDisplay(target);
+      return;
+    }
+
+    const start = performance.now();
+    const from = fromRef.current;
+    fromRef.current = target;
+    let frame = 0;
+
+    const tick = (now: number) => {
+      const elapsed = now - start;
+      const progress = Math.min(elapsed / duration, 1);
+      const eased = 1 - Math.pow(1 - progress, 3);
+      setDisplay(from + (target - from) * eased);
+      if (progress < 1) {
+        frame = requestAnimationFrame(tick);
+      }
+    };
+
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [target, active, duration]);
+
+  return display;
+};
 
 export const ButHowMuch = ({ value, unit, kind = "count", children }: ButHowMuchProps) => {
-  const [open, setOpen] = useState<boolean>(false);
+  const [open, setOpen] = useState(false);
 
-  const handleOpen = (e: MouseEvent<HTMLElement>) => {
-    e.preventDefault();
-    e.stopPropagation(); // evita chiusure immediate via backdrop
+  const handleOpen = (event: MouseEvent<HTMLElement>) => {
+    event.preventDefault();
+    event.stopPropagation();
+    if (kind !== "count") return;
     setOpen(true);
   };
 
   return (
     <span
       className="cursor-help underline decoration-dotted inline-flex items-center pointer-events-auto"
-      onMouseDown={handleOpen} // apri prima del click che potrebbe bubblaire
+      onMouseDown={handleOpen}
       title="But how much is it?"
     >
       {children ?? value}
-      <ScaleOverlay open={open} onClose={() => setOpen(false)} value={value} unit={unit} kind={kind} />
+      {kind === "count" && (
+        <ScaleOverlay open={open} onClose={() => setOpen(false)} value={value} unit={unit} kind={kind} />
+      )}
     </span>
   );
 };
 
 const ScaleOverlay = ({ open, onClose, value, unit, kind }: ScaleOverlayProps) => {
-  const eq = buildEquivalents(value, kind);
-  const Scene: (props: SceneProps) => JSX.Element =
-    kind === "volume_L" ? PoolScene :
-    kind === "distance_m" ? RulerScene :
-    kind === "time_s" ? HourglassScene :
-    BallsScene;
+  const shouldRender = kind === "count";
+  const animatedValue = useAnimatedNumber(value, open);
+  const equivalents = useMemo(
+    () => (shouldRender ? buildEquivalents(value, "count") : []),
+    [shouldRender, value],
+  );
 
-  // in SSR/non-browser non montare il portal
-  if (typeof document === "undefined") return null;
+  useEffect(() => {
+    if (!open) return;
+    const handleKey = (event: KeyboardEvent) => {
+      if (event.key === "Escape") onClose();
+    };
+    document.addEventListener("keydown", handleKey);
+    return () => document.removeEventListener("keydown", handleKey);
+  }, [open, onClose]);
+
+  if (typeof document === "undefined" || !shouldRender) return null;
+
+  const handleClose = () => onClose();
+  const unitLabel = unit;
 
   return createPortal(
     <AnimatePresence>
       {open && (
         <motion.div
-          className="fixed inset-0 z-[9999] backdrop-blur-md bg-black/60 flex items-center justify-center p-4"
-          initial={{ opacity: 0 }} animate={{ opacity: 1 }} exit={{ opacity: 0 }}
-          onMouseDown={(e) => { e.stopPropagation(); onClose(); }} // chiudi cliccando il backdrop
+          className="scale-overlay__backdrop"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          exit={{ opacity: 0 }}
+          onMouseDown={handleClose}
         >
           <motion.div
-            className="w-full max-w-5xl rounded-2xl overflow-hidden shadow-2xl"
-            style={{ background: "#0b1220" }} // contrasto sicuro
-            initial={{ scale: 0.96, opacity: 0 }} animate={{ scale: 1, opacity: 1 }} exit={{ scale: 0.96, opacity: 0 }}
-            onMouseDown={(e) => e.stopPropagation()} // blocca bubbling dentro il pannello
+            className="scale-overlay__panel"
+            initial={{ scale: 0.94, opacity: 0 }}
+            animate={{ scale: 1, opacity: 1 }}
+            exit={{ scale: 0.94, opacity: 0 }}
+            onMouseDown={event => event.stopPropagation()}
           >
-            <div className="p-4 flex items-baseline justify-between text-white">
-              <div className="text-xl">But how much is it?</div>
+            <div className="scale-overlay__header">
+              <h2 className="scale-overlay__heading">But how much is it?</h2>
               <button
-                className="opacity-70 hover:opacity-100"
-                onMouseDown={(e) => { e.stopPropagation(); onClose(); }}
+                type="button"
+                className="scale-overlay__close"
+                onClick={handleClose}
+                aria-label="Close scale overlay"
               >
-                ✕
+                ×
               </button>
             </div>
-
-            {/* Altezza inline per evitare Canvas a 0px */}
-            <div className="grid md:grid-cols-3">
-              <div className="md:col-span-2" style={{ height: 420 }}>
-                <Canvas camera={{ position: [0, 2.2, 4.2], fov: 55 }}>
-                  {/* Background del canvas per evitare “nero pece” */}
-                  <color attach="background" args={["#0e1426"]} />
-                  {/* Luci più generose */}
-                  <hemisphereLight intensity={0.9} />
-                  <ambientLight intensity={0.7} />
-                  <directionalLight position={[5, 6, 5]} intensity={1.2} />
-                  <Environment preset="city" />
-                  <Scene value={value} unit={unit} />
-                  <OrbitControls enablePan={false} />
-                </Canvas>
-              </div>
-
-              <div className="p-4 text-gray-100 space-y-3">
-                <div className="text-lg">
-                  <span className="font-semibold">{value.toLocaleString()}</span> {unit}
+            <div className="scale-overlay__content">
+              <CountScene value={value} unit={unitLabel} active={open} />
+              <div className="scale-overlay__details">
+                <div>
+                  <div className="scale-overlay__counter-label">Approximate count</div>
+                  <div>
+                    <span className="scale-overlay__counter-value">{formatCount(animatedValue)}</span>
+                    {unitLabel && <span className="scale-overlay__counter-unit">{unitLabel}</span>}
+                  </div>
                 </div>
-                <ul className="space-y-2">
-                  {eq.map((e, i) => (
-                    <li key={i} className="flex items-center gap-2">
-                      <span className="text-sm opacity-70">≈</span>
-                      <span className="font-semibold">{e.approx.toLocaleString()}</span>
-                      <span className="opacity-90">{e.label}</span>
-                    </li>
-                  ))}
-                </ul>
-                <div className="text-xs opacity-60">Click & drag per ruotare. Scene illustrative.</div>
+                <div>
+                  <div className="scale-overlay__hints">Exact value</div>
+                  <div className="scale-overlay__exact-row">
+                    <span className="scale-overlay__approx">{formatCount(value)}</span>
+                    {unitLabel && <span className="scale-overlay__counter-unit">{unitLabel}</span>}
+                  </div>
+                </div>
+                {equivalents.length > 0 && (
+                  <div>
+                    <div className="scale-overlay__hints">In other words</div>
+                    <ul className="scale-overlay__equivalents">
+                      {equivalents.map(item => (
+                        <li key={item.label}>
+                          <span className="scale-overlay__approx">{formatCount(item.approx)}</span>
+                          <span>{item.label}</span>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             </div>
           </motion.div>
         </motion.div>
       )}
     </AnimatePresence>,
-    document.body
+    document.body,
   );
 };
 
-/* ---------- Helper UI nel 3D ---------- */
-
-const Legend = ({ text }: { text: string }) => {
-  void text;
-  return (
-    <group position={[0, 1.15, 0]}>
-      <mesh>
-        <planeGeometry args={[2.8, 0.46]} />
-        <meshBasicMaterial color="#0e1627" transparent opacity={0.6} />
-      </mesh>
-    </group>
-  );
+type CountSceneProps = {
+  value: number;
+  unit?: string;
+  active: boolean;
 };
 
-/* ---------- Scenes ---------- */
-
-// numeri discreti → sfere
-const BallsScene = ({ value, unit }: SceneProps) => {
-  const step = pickStep(value, 260);
-  const count = Math.min(600, Math.ceil(value / step));
-  const r = 0.12, size = 3;
-
-  const bodies = useMemo<InstanceDesc[]>(() => {
-    const arr: InstanceDesc[] = [];
-    for (let i = 0; i < count; i++) {
-      const x = (Math.random() - 0.5) * (size - 1);
-      const z = (Math.random() - 0.5) * (size - 1);
-      const y = 2.2 + Math.random() * 1.8;
-      arr.push({ key: `b${i}`, position: [x, y, z], rotation: [0, 0, 0] });
+const CountScene = ({ value, unit, active }: CountSceneProps) => {
+  const { dots, legend } = useMemo(() => {
+    if (!Number.isFinite(value) || value <= 0) {
+      return { dots: [0], legend: formatLegend(1, unit) };
     }
-    return arr;
-  }, [count]);
+
+    const baseStep = pickStep(value, 160);
+    const step = value < baseStep ? value : baseStep;
+    const dotCount = Math.max(1, Math.min(MAX_DOTS, Math.round(value / step)));
+    const dots = Array.from({ length: dotCount }, (_, index) => index);
+    return { dots, legend: formatLegend(step, unit) };
+  }, [unit, value]);
 
   return (
-    <>
-      {/* Stanza */}
-      <RigidBody type="fixed">
-        <mesh position={[0, -0.75, 0]}>
-          <boxGeometry args={[size, 0.5, size]} />
-          <meshStandardMaterial color="#2a365d" roughness={0.6} metalness={0.05} />
-        </mesh>
-        {[-1, 1].map((s, i) => (
-          <mesh key={"wz" + i} position={[0, 0, (s * size) / 2]}>
-            <boxGeometry args={[size, 2, 0.5]} />
-            <meshStandardMaterial color="#1b243f" roughness={0.8} />
-          </mesh>
+    <div className="scale-overlay__visual">
+      <div className="count-scene__grid">
+        {dots.map(index => (
+          <span
+            key={index}
+            className="count-scene__dot"
+            style={{ animationDelay: active ? `${index * 0.018}s` : undefined }}
+          />
         ))}
-        {[-1, 1].map((s, i) => (
-          <mesh key={"wx" + i} position={[(s * size) / 2, 0, 0]} rotation={[0, Math.PI / 2, 0]}>
-            <boxGeometry args={[size, 2, 0.5]} />
-            <meshStandardMaterial color="#1b243f" roughness={0.8} />
-          </mesh>
-        ))}
-      </RigidBody>
-
-      {ENABLE_PHYSICS ? (
-        <Physics gravity={[0, -9.8, 0]}>
-          <InstancedRigidBodies instances={bodies as never} restitution={0.25} friction={0.5}>
-            <instancedMesh args={[undefined as never, undefined as never, bodies.length]}>
-              <sphereGeometry args={[r, 24, 24]} />
-              <meshStandardMaterial roughness={0.35} metalness={0.1} color="#9db4ff" />
-            </instancedMesh>
-          </InstancedRigidBodies>
-        </Physics>
-      ) : (
-        // Fallback senza fisica: vedi almeno le sfere
-        <instancedMesh args={[undefined as never, undefined as never, bodies.length]}>
-          <sphereGeometry args={[r, 24, 24]} />
-          <meshStandardMaterial roughness={0.35} metalness={0.1} color="#9db4ff" />
-        </instancedMesh>
-      )}
-
-      <Legend text={`1 sfera = ${step.toLocaleString()} ${unit ?? ""}`} />
-    </>
-  );
-};
-
-// volumi in litri → piscina
-const PoolScene = ({ value }: SceneProps) => {
-  const LtoM3 = (v: number) => v / 1000;
-  const poolM3 = LtoM3(2_500_000);
-  const frac = Math.min(1, LtoM3(value) / poolM3);
-  const y = -0.75 + frac * 1.3;
-
-  return (
-    <>
-      <mesh position={[0, -0.75, 0]}>
-        <boxGeometry args={[3, 1.5, 2]} />
-        <meshStandardMaterial color="#243357" roughness={0.7} />
-      </mesh>
-      <mesh position={[0, y, 0]}>
-        <boxGeometry args={[2.9, 1.3 * frac, 1.9]} />
-        <meshPhysicalMaterial transmission={0.1} transparent opacity={0.65} roughness={0.15} color="#3aa0ff" />
-      </mesh>
-      <Legend text={`Riempimento: ${(frac * 100).toFixed(1)}% piscina olimpionica`} />
-    </>
-  );
-};
-
-// distanze → righello
-const RulerScene = ({ value }: SceneProps) => {
-  const m = value;
-  return (
-    <>
-      <mesh rotation={[-Math.PI / 2, 0, 0]} position={[0, -0.2, 0]}>
-        <planeGeometry args={[10, 2]} />
-        <meshStandardMaterial color="#0f172a" />
-      </mesh>
-      {/* tacche visive */}
-      {[...Array(11)].map((_, i) => (
-        <mesh key={i} position={[-5 + i, 0, 0]}>
-          <boxGeometry args={[0.02, 0.4, 0.02]} />
-          <meshStandardMaterial color="#93c5fd" />
-        </mesh>
-      ))}
-      <Legend text={`≈ ${(m / 105).toFixed(2)} campi da calcio`} />
-    </>
-  );
-};
-
-// tempo → clessidra minimale
-const HourglassScene = ({ value }: SceneProps) => {
-  const years = value / 31_557_600;
-  return (
-    <>
-      <mesh position={[0, -0.6, 0]}>
-        <cylinderGeometry args={[0.5, 0.5, 0.2, 24]} />
-        <meshStandardMaterial color="#243357" roughness={0.6} />
-      </mesh>
-      <mesh position={[0, 0.6, 0]}>
-        <cylinderGeometry args={[0.5, 0.5, 0.2, 24]} />
-        <meshStandardMaterial color="#243357" roughness={0.6} />
-      </mesh>
-      <Legend text={`≈ ${years.toFixed(3)} anni`} />
-    </>
+      </div>
+      <p className="count-scene__legend">1 dot = {legend}</p>
+    </div>
   );
 };

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -909,7 +909,7 @@ body::before {
     pointer-events: none;
     transform: translateY(-10px);
     transition: opacity .2s ease, transform .2s ease;
-    z-index: 10;
+    z-index: 1200;
   }
 
   .app-navbar__dropdown--open {
@@ -1168,6 +1168,20 @@ body::before {
   flex-direction: column;
   gap: 16px;
   backdrop-filter: blur(18px);
+}
+
+.section-card--mock {
+  align-items: center;
+  justify-content: center;
+  min-height: 180px;
+}
+
+.section-card__mock-label {
+  font-size: 1.4rem;
+  font-weight: 600;
+  color: rgba(226, 232, 240, 0.85);
+  letter-spacing: .12em;
+  text-transform: uppercase;
 }
 
 .section-card__title {
@@ -1554,6 +1568,186 @@ body::before {
 .birth-wizard__skip:hover {
   transform: translateY(-1px);
   filter: brightness(1.05);
+}
+
+/* -----------------------------------------------------------
+   13.  Scale overlay (count visualizer)
+----------------------------------------------------------- */
+.scale-overlay__backdrop {
+  position: fixed;
+  inset: 0;
+  z-index: 2400;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: clamp(16px, 5vw, 32px);
+  background: rgba(8, 11, 19, 0.78);
+  backdrop-filter: blur(12px);
+}
+
+.scale-overlay__panel {
+  width: min(960px, 100%);
+  border-radius: 28px;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  background: rgba(15, 23, 42, 0.95);
+  box-shadow: 0 36px 72px rgba(10, 15, 30, 0.65);
+  overflow: hidden;
+  display: flex;
+  flex-direction: column;
+  color: var(--text-light);
+}
+
+.scale-overlay__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  padding: clamp(18px, 3vw, 26px);
+  border-bottom: 1px solid rgba(129, 140, 248, 0.25);
+}
+
+.scale-overlay__heading {
+  margin: 0;
+  font-size: 1.1rem;
+  letter-spacing: .14em;
+  text-transform: uppercase;
+}
+
+.scale-overlay__close {
+  border: 1px solid rgba(148, 163, 184, 0.45);
+  border-radius: 999px;
+  background: rgba(30, 41, 59, 0.65);
+  color: var(--text-light);
+  padding: 6px 12px;
+  font-size: .85rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: background .2s ease, transform .2s ease;
+}
+
+.scale-overlay__close:hover {
+  background: rgba(51, 65, 85, 0.8);
+  transform: translateY(-1px);
+}
+
+.scale-overlay__content {
+  display: grid;
+  grid-template-columns: minmax(0, 1.15fr) minmax(0, 0.85fr);
+  gap: clamp(20px, 4vw, 32px);
+  padding: clamp(24px, 4vw, 36px);
+}
+
+.scale-overlay__visual {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.count-scene__grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fill, minmax(20px, 1fr));
+  gap: 12px;
+}
+
+.count-scene__dot {
+  width: 20px;
+  height: 20px;
+  border-radius: 50%;
+  background: radial-gradient(circle at 30% 30%, rgba(165, 180, 252, 0.95), rgba(59, 130, 246, 0.4));
+  opacity: 0;
+  animation: count-pop .45s ease forwards;
+}
+
+@keyframes count-pop {
+  from {
+    transform: scale(0.4);
+    opacity: 0;
+  }
+  to {
+    transform: scale(1);
+    opacity: 1;
+  }
+}
+
+.count-scene__legend {
+  font-size: .85rem;
+  color: var(--text-muted);
+  text-transform: uppercase;
+  letter-spacing: .12em;
+}
+
+.scale-overlay__details {
+  display: flex;
+  flex-direction: column;
+  gap: 18px;
+}
+
+.scale-overlay__counter-label {
+  font-size: .75rem;
+  letter-spacing: .2em;
+  text-transform: uppercase;
+  color: rgba(226, 232, 240, 0.6);
+}
+
+.scale-overlay__counter-value {
+  font-size: clamp(1.8rem, 5vw, 2.6rem);
+  font-weight: 700;
+  letter-spacing: .06em;
+  color: var(--indigo-100);
+}
+
+.scale-overlay__counter-unit {
+  font-size: .95rem;
+  color: rgba(226, 232, 240, 0.75);
+  margin-left: 8px;
+  text-transform: uppercase;
+  letter-spacing: .14em;
+}
+
+.scale-overlay__equivalents {
+  margin: 0;
+  padding: 0;
+  list-style: none;
+  display: grid;
+  gap: 10px;
+}
+
+.scale-overlay__equivalents li {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: .95rem;
+}
+
+.scale-overlay__equivalents .scale-overlay__approx {
+  font-weight: 600;
+  color: var(--text-light);
+}
+
+.scale-overlay__hints {
+  font-size: .7rem;
+  text-transform: uppercase;
+  letter-spacing: .16em;
+  color: rgba(226, 232, 240, 0.55);
+}
+
+.scale-overlay__exact-row {
+  display: flex;
+  align-items: baseline;
+  gap: 10px;
+  font-size: 1rem;
+  color: var(--text-light);
+}
+
+@media (max-width: 900px) {
+  .scale-overlay__content {
+    grid-template-columns: 1fr;
+  }
+
+  .count-scene__grid {
+    grid-template-columns: repeat(auto-fill, minmax(18px, 1fr));
+    gap: 10px;
+  }
 }
 
 @media (max-width: 720px) {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,6 +1,7 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
 import { Navbar, Title } from "../components/common/Headers";
+import MockCard from "../components/common/MockCard";
 import { useBirthWizard } from "../hooks/useBirthWizard";
 
 export default function About() {
@@ -12,30 +13,9 @@ export default function About() {
       <main className="page">
         <Title />
         <section className="section-grid">
-          <article className="section-card">
-            <h2 className="section-card__title">Our mission</h2>
-            <p className="section-card__text">
-              Age Milestones is being designed as a calm companion that reframes time. By blending scientific
-              references with poetic storytelling we hope to help you feel grounded, inspired, and curious about
-              every chapter ahead.
-            </p>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">Built with curiosity</h2>
-            <p className="section-card__text">
-              The project is crafted in Florence by Niccolò Mei Innocenti. This space will later include a short
-              bio, credits, and behind-the-scenes notes about the tools used to bring each visualization to life.
-            </p>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">What&apos;s coming</h2>
-            <p className="section-card__text">
-              Expect deep dives on how perspectives are calculated, transparency about data usage, and links to
-              further readings. If you have suggestions, the upcoming feedback form will be the best way to reach out.
-            </p>
-          </article>
+          <MockCard />
+          <MockCard />
+          <MockCard />
         </section>
       </main>
       <Footer />

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -152,11 +152,11 @@ export default function Milestones() {
   }, []);
 
   const renderNumber = useCallback((value: number, label: string) => {
-    const { kind, unit } = inferKindUnit(label);
+    const { kind, unit, disableOverlay } = inferKindUnit(label);
     return (
       <span className="inline-flex items-center">
         <span>{formatDisplay(value)}</span>
-        <HowMuchHint value={value} unit={unit} kind={kind} />
+        <HowMuchHint value={value} unit={unit} kind={kind} disabled={disableOverlay} />
       </span>
     );
   }, []);

--- a/src/pages/Personalize.tsx
+++ b/src/pages/Personalize.tsx
@@ -1,6 +1,7 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
 import { Navbar, Title } from "../components/common/Headers";
+import MockCard from "../components/common/MockCard";
 import { useBirthWizard } from "../hooks/useBirthWizard";
 
 export default function Personalize() {
@@ -12,41 +13,9 @@ export default function Personalize() {
       <main className="page">
         <Title />
         <section className="section-grid">
-          <article className="section-card">
-            <h2 className="section-card__title">Tailor your journey</h2>
-            <p className="section-card__text">
-              The personalization hub will let you name milestones, pick iconography, and apply themes that
-              reflect your story. Imagine toggles for night mode, typography, and mindful focus modes.
-            </p>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">Signature palette</h2>
-            <div className="section-card__chips">
-              <span className="section-card__chip">Neon dusk</span>
-              <span className="section-card__chip">Aurora</span>
-              <span className="section-card__chip">Minimal</span>
-            </div>
-            <p className="section-card__text">
-              Themes will adapt backgrounds, gradients, and typographic tone so the experience always feels
-              personal.
-            </p>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">Focus presets</h2>
-            <ul className="section-card__list">
-              <li>
-                <span className="section-card__bullet" />Career checkpoints
-              </li>
-              <li>
-                <span className="section-card__bullet" />Family and relationships
-              </li>
-              <li>
-                <span className="section-card__bullet" />Health and mindfulness streaks
-              </li>
-            </ul>
-          </article>
+          <MockCard />
+          <MockCard />
+          <MockCard />
         </section>
       </main>
       <Footer />

--- a/src/pages/Timescales.tsx
+++ b/src/pages/Timescales.tsx
@@ -1,6 +1,7 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
 import { Navbar, Title } from "../components/common/Headers";
+import MockCard from "../components/common/MockCard";
 import { useBirthWizard } from "../hooks/useBirthWizard";
 
 export default function Timescales() {
@@ -12,46 +13,9 @@ export default function Timescales() {
       <main className="page">
         <Title />
         <section className="section-grid">
-          <article className="section-card">
-            <h2 className="section-card__title">Layered timescales</h2>
-            <p className="section-card__text">
-              Preview how your life aligns with cosmic, cultural, and biological clocks. Each block will
-              become an interactive lens that recalculates your milestones on the fly.
-            </p>
-            <ul className="section-card__list">
-              <li>
-                <span className="section-card__bullet" />Solar cycles and equinox rhythms
-              </li>
-              <li>
-                <span className="section-card__bullet" />Planetary orbits compared side by side
-              </li>
-              <li>
-                <span className="section-card__bullet" />Meaningful anniversaries auto-detected
-              </li>
-            </ul>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">Timeline preview</h2>
-            <div className="section-card__preview">Interactive mock timeline</div>
-            <p className="section-card__text">
-              Drag through decades, zoom into months, and reveal hidden events generated from your birth data.
-              Tooltips and contextual hints will help make sense of every tick.
-            </p>
-            <div className="section-card__chips">
-              <span className="section-card__chip">Daily</span>
-              <span className="section-card__chip">Seasonal</span>
-              <span className="section-card__chip">Deep time</span>
-            </div>
-          </article>
-
-          <article className="section-card">
-            <h2 className="section-card__title">What&apos;s next</h2>
-            <p className="section-card__text">
-              This area will soon host widgets that let you bookmark key checkpoints, compare them with friends,
-              and export custom countdowns.
-            </p>
-          </article>
+          <MockCard />
+          <MockCard />
+          <MockCard />
         </section>
       </main>
       <Footer />

--- a/src/utils/scaleConstants.ts
+++ b/src/utils/scaleConstants.ts
@@ -146,7 +146,13 @@ export const KIND_BY_LABEL: Array<{ test: RegExp; k: KindUnit }> = [
 
 export const inferKindUnit = (label: string): KindUnit => {
   for (const r of KIND_BY_LABEL) {
-    if (r.test.test(label)) return r.k;
+    if (r.test.test(label)) {
+      const result: KindUnit = { ...r.k };
+      if (result.kind !== "count") {
+        result.disableOverlay = true;
+      }
+      return result;
+    }
   }
   return { kind: "count" };
 };


### PR DESCRIPTION
## Summary
- replace the heavy 3D "how much" overlay with a lightweight count visualizer and polish its styling
- only surface the question mark hint for large count values and non-disabled units
- swap secondary page cards with explicit mock placeholders and lift navigation/overlay stacking to the foreground

## Testing
- npm run lint
- npm run test -- --run *(fails: existing formatSmall expectation)*

------
https://chatgpt.com/codex/tasks/task_e_68cecda2ebcc832fa2c21fc85aafc1ec