### PR TITLE
Refine layout interactions and update about content

### DIFF
--- a/src/components/common/Headers.tsx
+++ b/src/components/common/Headers.tsx
@@ -1,8 +1,14 @@
 import { useEffect, useId, useRef, useState } from "react";
 import { Link, useLocation } from "react-router-dom";
 
-export function Title() {
-  return <h1 className="title">AGE MILESTONES</h1>;
+type TitleProps = {
+  variant?: "page" | "navbar";
+};
+
+export function Title({ variant = "page" }: TitleProps) {
+  const Element: keyof JSX.IntrinsicElements = variant === "page" ? "h1" : "span";
+  const className = variant === "page" ? "title" : "title title--navbar";
+  return <Element className={className}>AGE MILESTONES</Element>;
 }
 
 const NAV_ITEMS = [
@@ -55,9 +61,9 @@ export function Navbar({ onEditBirthDate }: NavbarProps) {
 
   return (
     <header className="app-navbar">
-      <Link to="/" className="app-navbar__brand">
+      <Link to="/" className="app-navbar__brand" aria-label="Go to landing page">
         <span className="app-navbar__brand-mark" aria-hidden="true" />
-        Age Milestones
+        <Title variant="navbar" />
       </Link>
 
       <div className="app-navbar__actions">

--- a/src/css/index.css
+++ b/src/css/index.css
@@ -128,6 +128,15 @@ body::before {
   width: min(100%, 22ch);
 }
 
+.title--navbar {
+  margin: 0;
+  width: auto;
+  text-align: left;
+  font-size: clamp(1.4rem, 3vw, 2.4rem);
+  letter-spacing: .06em;
+  display: inline-block;
+}
+
 .subtitle {
   font-family: system-ui, sans-serif;
   text-align: center;
@@ -778,6 +787,8 @@ body::before {
     border-radius: 24px;
     box-shadow: 0 26px 48px rgba(15, 23, 42, 0.45);
     backdrop-filter: blur(18px);
+    position: relative;
+    z-index: 1800;
   }
 
   .app-navbar__brand {
@@ -785,11 +796,8 @@ body::before {
     align-items: center;
     gap: 12px;
     text-decoration: none;
-    font-size: .95rem;
-    letter-spacing: .12em;
-    font-weight: 700;
-    text-transform: uppercase;
-    color: var(--text-light);
+    color: inherit;
+    min-width: 0;
   }
 
   .app-navbar__brand-mark {
@@ -1090,6 +1098,7 @@ body::before {
   background: radial-gradient(ellipse at center, rgba(0, 227, 255, 0.35) 0%, transparent 70%);
   opacity: 0;
   transition: opacity .3s ease;
+  pointer-events: none;
 }
 
 .age-table .age-val.updated {
@@ -1196,6 +1205,22 @@ body::before {
   color: var(--text-muted);
   font-size: .95rem;
   line-height: 1.6;
+}
+
+.about-card {
+  align-items: flex-start;
+  gap: 18px;
+  text-align: left;
+}
+
+.about-card__content {
+  color: var(--text-light);
+  line-height: 1.6;
+}
+
+.about-card__content .quote {
+  color: var(--indigo-100);
+  text-shadow: 0 0 4px rgba(165, 180, 252, .35);
 }
 
 .section-card__list {

--- a/src/pages/About.tsx
+++ b/src/pages/About.tsx
@@ -1,21 +1,28 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
-import { Navbar, Title } from "../components/common/Headers";
-import MockCard from "../components/common/MockCard";
+import { Navbar } from "../components/common/Headers";
 import { useBirthWizard } from "../hooks/useBirthWizard";
+import { landingIntro } from "../components/unused/constants";
 
 export default function About() {
   const { birthDate, birthTime, isOpen, openWizard, closeWizard, completeWizard } = useBirthWizard();
+  const [, ...restParagraphs] = landingIntro.trim().split("<br/><br/>");
+  const aboutContent = restParagraphs.length
+    ? restParagraphs.join("<br/><br/>")
+    : landingIntro.trim();
 
   return (
     <>
       <Navbar onEditBirthDate={openWizard} />
       <main className="page">
-        <Title />
-        <section className="section-grid">
-          <MockCard />
-          <MockCard />
-          <MockCard />
+        <section className="card about-card">
+          <h2 className="section-card__title">A deeper look</h2>
+          <div
+            className="about-card__content"
+            dangerouslySetInnerHTML={{
+              __html: aboutContent,
+            }}
+          />
         </section>
       </main>
       <Footer />

--- a/src/pages/Landing.tsx
+++ b/src/pages/Landing.tsx
@@ -1,4 +1,4 @@
-import { useCallback, useMemo, useState } from "react";
+import { useCallback, useMemo } from "react";
 import { useNavigate } from "react-router-dom";
 
 import { landingIntro } from "../components/unused/constants.ts";
@@ -11,11 +11,7 @@ export default function Landing() {
   const nav = useNavigate();
   const { birthDate, birthTime, isOpen: wizardOpen, openWizard, closeWizard, completeWizard } =
     useBirthWizard();
-  const [expanded, setExpanded] = useState(false);
-  const [firstParagraph, ...restParagraphs] = landingIntro
-    .trim()
-    .split("<br/><br/>");
-  const remainder = restParagraphs.join("<br/><br/>");
+  const [firstParagraph = ""] = landingIntro.trim().split("<br/><br/>");
 
   const storedSummary = useMemo(() => {
     if (!birthDate) return null;
@@ -45,12 +41,9 @@ export default function Landing() {
             <div
               className="intro"
               dangerouslySetInnerHTML={{
-                __html: expanded ? `${firstParagraph}<br/><br/>${remainder}` : firstParagraph,
+                __html: firstParagraph,
               }}
             />
-            <button className="button more-btn" onClick={() => setExpanded(!expanded)}>
-              Learn more
-            </button>
             <hr className="divider" />
             <div className="landing__cta">
               <p className="muted">Set up your date of birth here</p>

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -5,7 +5,7 @@ import dayjs from "dayjs";
 import Timeline, { type TimelineEvent, type TimelineTick } from "../components/Timeline";
 import AgeTable from "../components/AgeTable";
 import Footer from "../components/common/Footer";
-import { Title, Navbar } from "../components/common/Headers";
+import { Navbar } from "../components/common/Headers";
 import { useMilestone } from "../hooks/useMilestone";
 import { TAB_ROWS } from "../utils/perspectivesConstants";
 import "../css/index.css";
@@ -167,7 +167,6 @@ export default function Milestones() {
     <>
       <Navbar onEditBirthDate={openWizard} />
       <main className="page milestones-page">
-        <Title />
         <section className="perspective-card">
           <div className="tabs perspective-card__tabs" role="tablist" aria-label="Perspectives">
             {allTabs.map(t => (

--- a/src/pages/Personalize.tsx
+++ b/src/pages/Personalize.tsx
@@ -1,6 +1,6 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
-import { Navbar, Title } from "../components/common/Headers";
+import { Navbar } from "../components/common/Headers";
 import MockCard from "../components/common/MockCard";
 import { useBirthWizard } from "../hooks/useBirthWizard";
 
@@ -11,7 +11,6 @@ export default function Personalize() {
     <>
       <Navbar onEditBirthDate={openWizard} />
       <main className="page">
-        <Title />
         <section className="section-grid">
           <MockCard />
           <MockCard />

--- a/src/pages/Timescales.tsx
+++ b/src/pages/Timescales.tsx
@@ -1,6 +1,6 @@
 import BirthDateWizard from "../components/BirthDateWizard";
 import Footer from "../components/common/Footer";
-import { Navbar, Title } from "../components/common/Headers";
+import { Navbar } from "../components/common/Headers";
 import MockCard from "../components/common/MockCard";
 import { useBirthWizard } from "../hooks/useBirthWizard";
 
@@ -11,7 +11,6 @@ export default function Timescales() {
     <>
       <Navbar onEditBirthDate={openWizard} />
       <main className="page">
-        <Title />
         <section className="section-grid">
           <MockCard />
           <MockCard />


### PR DESCRIPTION
## Summary
- move the gradient title into the main navbar via a reusable variant and drop duplicate headings on content pages
- keep the landing hero concise while relocating the expanded introduction into a dedicated About card with supporting styles
- restore the “how much” helper button hover/click behaviour and ensure the navbar dropdown layers above underlying cards

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cf50896920832f83cae5f94fad2d66