### PR TITLE
Timeline: implement lane-based Time Map + detail panel (Refactor_3 Phase 5)

### DIFF
--- a/refactor_docs/refactor_3/DECISIONS.md
+++ b/refactor_docs/refactor_3/DECISIONS.md
@@ -117,3 +117,68 @@ La prop `renderNumber` è stata rimossa da `AgeTable`. La logica di apertura del
 
 ### Motivazione
 Principio di **least knowledge**: `Milestones.tsx` non deve sapere come funziona l'overlay. `AgeTable` è l'unico componente con accesso diretto ai valori raw e al profilo di ogni riga — è il posto corretto per decidere quando mostrare il modale.
+
+---
+
+## D-06 — Time Map a lane parallele (Fase 5)
+
+**Data:** 2026-04-20  
+**Fase:** 5 — Timeline Evolution
+
+### Decisione
+Introdotta architettura a lane condivise con un viewport unico (`center + spanMs`) e `scaleMode` unico:
+- `personal`
+- `historical`
+- `markers`
+
+Ogni evento ora può dichiarare `lane?: TimelineLane`; assenza di lane => fallback `personal` per backward compatibility.
+
+### Motivazione
+La timeline monolinea produceva clustering eccessivo e sovrapposizioni. Le lane separano semantica e densità informativa senza duplicare la logica di pan/zoom.
+
+### Impatto tecnico
+- `TimelineEvent` esteso con `lane`.
+- `Timeline.tsx` ora costruisce i render items per lane (`buildRenderItems` riusata lane-by-lane).
+- Ruler ticks condivisa in alto; eventi distribuiti verticalmente per lane.
+
+### Trade-off
+- Altezza asse aumentata (300/330px) per mantenere leggibilità.
+- I marker condividono ancora il medesimo engine di grouping (coerente, ma non lane-aware per collisioni inter-lane — non necessario in questa fase).
+
+---
+
+## D-07 — Sostituzione SubTimeline con Detail Panel
+
+**Data:** 2026-04-20  
+**Fase:** 5 — Timeline Evolution
+
+### Decisione
+La `SubTimeline` espansa è stata sostituita da `TimelineDetailPanel`:
+- Desktop: pannello ancorato sotto la timeline
+- Mobile: half-sheet con dismiss via drag verticale (`Framer Motion drag="y"`)
+
+Selezionando un marker singolo viene mostrato 1 evento; selezionando un gruppo viene mostrata la lista degli eventi sovrapposti.
+
+### Motivazione
+Il pattern precedente richiedeva contesto mentale extra (mini-axis nel mini-axis). Il detail panel riduce il carico cognitivo e rende il contenuto gerarchico esplicito.
+
+### Trade-off
+- Persa la mini-rappresentazione temporale locale del gruppo.
+- Guadagnata una UX più stabile su mobile (niente outside-click race nel path principale).
+
+---
+
+## D-08 — Lane visibility controls persistenti
+
+**Data:** 2026-04-20  
+**Fase:** 5 — Timeline Evolution
+
+### Decisione
+Aggiunto stato preferenze per visibilità lane:
+- `pref_visibleTimelineLanes` (localStorage)
+- API context: `visibleTimelineLanes`, `toggleTimelineLane`
+
+UI in `Milestones.tsx`: sezione "Visible lanes" con chip toggle, con guardrail "almeno una lane attiva".
+
+### Motivazione
+In una Time Map multi-layer, la riduzione di rumore è cruciale. L'utente può spegnere ciò che non è rilevante nel suo flusso esplorativo.

--- a/refactor_docs/refactor_3/PLAN.md
+++ b/refactor_docs/refactor_3/PLAN.md
@@ -229,7 +229,7 @@ Persistenza: `localStorage` key `"user_profile"`.
 
 ---
 
-### Fase 5 — Timeline Evolution: verso il Time Map (stimata: 5-8 giorni)
+### ✅ Fase 5 — Timeline Evolution: verso il Time Map (Completata: 2026-04-20)
 
 > **Nota:** Questa è la fase più ambiziosa e può essere suddivisa in sub-fasi.
 
@@ -342,10 +342,9 @@ Il progetto è stato rinominato **Kronoscope** (Fase 0). Il nome evoca:
 | Fase 2 — Data Model: Metriche con Range | ✅ Completata | Fase 1 |
 | Fase 3 — Personalizzazione Utente | ✅ Completata | Fase 2 |
 | Fase 4 — About Page Revamp + DOB Simplification | ✅ Completata | Fase 0 |
-| Fase 5 — Timeline Evolution (Time Map) | 🔲 Da fare | Fase 1, Fase 2 |
+| Fase 5 — Timeline Evolution (Time Map) | ✅ Completata | Fase 1, Fase 2 |
 | Fase 6 — 3D Strategy | 🔲 Da fare | Nessuna |
 
 ---
 
 *Questo piano è un documento vivente. Aggiornare lo stato delle fasi man mano che vengono completate.*
-

--- a/src/components/timeline/EventElement.tsx
+++ b/src/components/timeline/EventElement.tsx
@@ -42,9 +42,19 @@ type EventElementProps = {
   variant: "main" | "sub";
   range: Range;
   now: number;
+  onSelect?: (event: TimelineEvent) => void;
+  selected?: boolean;
 };
 
-export function EventElement({ event, leftPercent, variant, range, now }: EventElementProps) {
+export function EventElement({
+  event,
+  leftPercent,
+  variant,
+  range,
+  now,
+  onSelect,
+  selected = false,
+}: EventElementProps) {
   const placement   = event.placement  ?? "above";
   const markerShape = event.markerShape ?? "dot";
   const accent: Accent = event.accent  ?? "default";
@@ -66,6 +76,7 @@ export function EventElement({ event, leftPercent, variant, range, now }: EventE
   ];
   if (variant === "main" && isClamped) eventClasses.push("timeline__event--clamped");
   if (event.id === "birth") eventClasses.push("timeline__event--birth");
+  if (selected) eventClasses.push("timeline__event--selected");
 
   const labelClasses = ["timeline__label", `timeline__label--${accent}`];
 
@@ -80,6 +91,15 @@ export function EventElement({ event, leftPercent, variant, range, now }: EventE
       tabIndex={0}
       aria-labelledby={labelId}
       aria-label={event.label}
+      aria-pressed={selected}
+      onClick={() => onSelect?.(event)}
+      onKeyDown={evt => {
+        if (!onSelect) return;
+        if (evt.key === "Enter" || evt.key === " ") {
+          evt.preventDefault();
+          onSelect(event);
+        }
+      }}
     >
       <span
         className={`timeline__marker timeline__marker--${markerShape}`}
@@ -98,4 +118,3 @@ export function EventElement({ event, leftPercent, variant, range, now }: EventE
     </div>
   );
 }
-

--- a/src/components/timeline/Timeline.tsx
+++ b/src/components/timeline/Timeline.tsx
@@ -1,10 +1,3 @@
-/**
- * src/components/timeline/Timeline.tsx
- * Main timeline component — manages viewport state, pan/zoom,
- * and composes axis, events, sub-timeline and controls.
- *
- * ~270 lines (down from 879 in the monolith).
- */
 import {
   useCallback,
   useEffect,
@@ -20,7 +13,7 @@ import {
 import { AnimatePresence } from "framer-motion";
 import { useElementSize } from "../../hooks/useElementSize";
 import { usePreferences } from "../../context/PreferencesContext";
-import { usePinchZoom }   from "../../hooks/usePinchZoom";
+import { usePinchZoom } from "../../hooks/usePinchZoom";
 import {
   viewportToRange,
   applyZoom,
@@ -34,23 +27,22 @@ import {
   type Viewport,
 } from "../../utils/scaleTransform";
 import { buildRenderItems } from "./buildRenderItems";
-import { EventElement }     from "./EventElement";
-import { SubTimeline }      from "./SubTimeline";
+import { EventElement } from "./EventElement";
 import { TimelineControls } from "./TimelineControls";
-import type { Props, RenderGroup } from "./types";
+import { TimelineDetailPanel } from "./TimelineDetailPanel";
+import { LANE_META, type DetailPanelItem, type Props, type TimelineLane } from "./types";
 import { SLIDER_RESOLUTION, PAN_THRESHOLD_PX } from "./types";
 
-// ── Hover formatting ──────────────────────────────────────────
-
 const MS_IN_HOUR = 60 * 60 * 1_000;
-const MS_IN_DAY  = 24 * MS_IN_HOUR;
+const MS_IN_DAY = 24 * MS_IN_HOUR;
+const LANE_ORDER: TimelineLane[] = ["personal", "historical", "markers"];
 
 const hoverDateFormatter = new Intl.DateTimeFormat(undefined, {
   day: "numeric", month: "short", year: "numeric",
 });
 
 const formatHoverTiming = (dateMs: number, now: number): string => {
-  const diff    = dateMs - now;
+  const diff = dateMs - now;
   const absDiff = Math.abs(diff);
   if (absDiff < 1_000) return "Now";
 
@@ -59,46 +51,38 @@ const formatHoverTiming = (dateMs: number, now: number): string => {
     const d = `${years >= 10 ? Math.round(years) : years.toFixed(1)} years`;
     return diff > 0 ? `In ${d}` : `${d} ago`;
   }
-  const days  = Math.floor(absDiff / MS_IN_DAY);
+
+  const days = Math.floor(absDiff / MS_IN_DAY);
   const hours = Math.floor((absDiff % MS_IN_DAY) / MS_IN_HOUR);
   const parts: string[] = [];
-  if (days  > 0) parts.push(`${days}d`);
+  if (days > 0) parts.push(`${days}d`);
   if (hours > 0 && days < 60) parts.push(`${hours}h`);
   if (!parts.length) {
     const minutes = Math.floor((absDiff % MS_IN_HOUR) / 60_000);
     parts.push(minutes > 0 ? `${minutes}m` : "< 1m");
   }
+
   const d = parts.slice(0, 2).join(" ");
   return diff > 0 ? `In ${d}` : `${d} ago`;
 };
 
-// ── Component ─────────────────────────────────────────────────
-
-export default function Timeline({
-  range, value, onChange, events, renderValue,
-}: Props) {
-  // ── Viewport state ────────────────────────────────────────
+export default function Timeline({ range, value, onChange, events, renderValue }: Props) {
   const [viewport, setViewport] = useState<Viewport>(() => ({
     center: (range.start + range.end) / 2,
     spanMs: range.end - range.start,
   }));
 
-  // Reset viewport when external range changes (e.g. birthdate edited)
   useEffect(() => {
     setViewport({ center: (range.start + range.end) / 2, spanMs: range.end - range.start });
   }, [range.start, range.end]);
 
-  // Always-current ref avoids stale closures in wheel/pointer callbacks
   const viewportRef = useRef(viewport);
   viewportRef.current = viewport;
 
-  // ── Scale mode (lin / log) ────────────────────────────────
   const { scaleMode } = usePreferences();
-  const scaleModeRef  = useRef(scaleMode);
+  const scaleModeRef = useRef(scaleMode);
   scaleModeRef.current = scaleMode;
 
-  // Briefly add the transitioning class when scale mode changes so that
-  // CSS position transitions fire only during the mode switch (not during pan/zoom).
   const [isScaleSwitching, setIsScaleSwitching] = useState(false);
   const prevScaleModeRef = useRef(scaleMode);
   useEffect(() => {
@@ -110,108 +94,79 @@ export default function Timeline({
   }, [scaleMode]);
 
   const viewRange = useMemo(() => viewportToRange(viewport), [viewport]);
-
-  const safeValue   = clamp(value, viewRange.start, viewRange.end);
-  const valueRatio  = valueToRatio(safeValue, viewRange, scaleMode);
+  const safeValue = clamp(value, viewRange.start, viewRange.end);
+  const valueRatio = valueToRatio(safeValue, viewRange, scaleMode);
   const sliderValue = valueRatio * SLIDER_RESOLUTION;
 
-  // ── Live clock ────────────────────────────────────────────
   const [now, setNow] = useState(() => Date.now());
   useEffect(() => {
     const id = window.setInterval(() => setNow(Date.now()), 1_000);
     return () => window.clearInterval(id);
   }, []);
 
-  // ── Axis ref (size + DOM) ─────────────────────────────────
   const [axisRef, axisSize] = useElementSize<HTMLDivElement>();
   const axisNodeRef = useRef<HTMLDivElement | null>(null);
-  const setAxisRef  = useCallback((node: HTMLDivElement | null) => {
+  const setAxisRef = useCallback((node: HTMLDivElement | null) => {
     axisNodeRef.current = node;
     axisRef(node);
   }, [axisRef]);
 
-  // ── Group button node refs ────────────────────────────────
-  const groupNodesRef = useRef<Map<string, HTMLButtonElement>>(new Map());
-  const setGroupNode  = useCallback((id: string, node: HTMLButtonElement | null) => {
-    if (node) groupNodesRef.current.set(id, node);
-    else      groupNodesRef.current.delete(id);
+  const sortedEvents = useMemo(() => events.slice().sort((a, b) => a.value - b.value), [events]);
+  const autoTicks = useMemo(() => generateTicks(viewRange, scaleMode), [viewRange, scaleMode]);
+
+  const renderItemsByLane = useMemo(() => {
+    const map: Record<TimelineLane, ReturnType<typeof buildRenderItems>> = {
+      personal: [], historical: [], markers: [],
+    };
+
+    for (const lane of LANE_ORDER) {
+      const laneEvents = sortedEvents.filter(event => (event.lane ?? "personal") === lane);
+      map[lane] = buildRenderItems(laneEvents, viewRange, axisSize.width, scaleMode);
+    }
+
+    return map;
+  }, [sortedEvents, viewRange, axisSize.width, scaleMode]);
+
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null);
+  const [selectedItems, setSelectedItems] = useState<DetailPanelItem[]>([]);
+  const [hoverState, setHoverState] = useState<{ dateMs: number; leftPercent: number } | null>(null);
+  const [isPanning, setIsPanning] = useState(false);
+
+  const clearSelection = useCallback(() => {
+    setSelectedGroupId(null);
+    setSelectedItems([]);
   }, []);
 
-  // ── Derived rendering data ────────────────────────────────
-  const sortedEvents = useMemo(
-    () => events.slice().sort((a, b) => a.value - b.value),
-    [events],
-  );
-  const autoTicks   = useMemo(() => generateTicks(viewRange, scaleMode), [viewRange, scaleMode]);
-  const renderItems = useMemo(
-    () => buildRenderItems(sortedEvents, viewRange, axisSize.width, scaleMode),
-    [sortedEvents, viewRange, axisSize.width, scaleMode],
-  );
-
-  // ── Active group (sub-timeline) ───────────────────────────
-  const [activeGroupId, setActiveGroupId] = useState<string | null>(null);
-  const [hoverState, setHoverState]        = useState<{ dateMs: number; leftPercent: number } | null>(null);
-  const [isPanning, setIsPanning]          = useState(false);
-
-  const activeGroup     = useMemo(() => {
-    if (!activeGroupId) return null;
-    return (
-      renderItems.find(i => i.type === "group" && i.id === activeGroupId) as RenderGroup | undefined
-    ) ?? null;
-  }, [activeGroupId, renderItems]);
-
-  const activeGroupNode = activeGroup
-    ? (groupNodesRef.current.get(activeGroup.id) ?? null)
-    : null;
-
-  // Close group if it disappears (e.g. after zoom)
-  useEffect(() => {
-    if (activeGroupId && !activeGroup) setActiveGroupId(null);
-  }, [activeGroup, activeGroupId]);
-
-  // Keyboard: Escape closes sub-timeline
-  useEffect(() => {
-    if (!activeGroupId) return;
-    const handler = (e: KeyboardEvent) => { if (e.key === "Escape") setActiveGroupId(null); };
-    window.addEventListener("keydown", handler);
-    return () => window.removeEventListener("keydown", handler);
-  }, [activeGroupId]);
-
-  // ── Pan handlers ──────────────────────────────────────────
-  const panStartRef  = useRef<{ clientX: number; centerAtStart: number; spanAtStart: number } | null>(null);
+  const panStartRef = useRef<{ clientX: number; centerAtStart: number; spanAtStart: number } | null>(null);
   const isPanningRef = useRef(false);
-  /** Shared with usePinchZoom — true while a 2-finger pinch is in progress */
   const isPinchingRef = useRef(false);
 
-  // ── Pinch-to-zoom ─────────────────────────────────────────
   const { showPinchHint } = usePinchZoom({
     axisNodeRef,
     viewportRef,
     scaleModeRef,
     setViewport,
     isPinchingRef,
-    /** Abort any ongoing single-finger pan when a second finger lands */
     onPinchStart: () => {
-      panStartRef.current  = null;
+      panStartRef.current = null;
       isPanningRef.current = false;
       setIsPanning(false);
     },
   });
 
   const handleAxisPointerDown = useCallback((evt: ReactPointerEvent<HTMLDivElement>) => {
-    if ((evt.target as HTMLElement).closest("button")) return;
-    if (isPinchingRef.current)    return; // yield to active pinch
-    if (panStartRef.current !== null) return; // already tracking a pointer
+    const target = evt.target as HTMLElement;
+    if (target.closest("button") || target.closest(".timeline__event")) return;
+    if (isPinchingRef.current || panStartRef.current !== null) return;
     evt.preventDefault();
     evt.currentTarget.setPointerCapture(evt.pointerId);
     const vp = viewportRef.current;
-    panStartRef.current  = { clientX: evt.clientX, centerAtStart: vp.center, spanAtStart: vp.spanMs };
+    panStartRef.current = { clientX: evt.clientX, centerAtStart: vp.center, spanAtStart: vp.spanMs };
     isPanningRef.current = false;
   }, []);
 
   const handleAxisPointerMove = useCallback((evt: ReactPointerEvent<HTMLDivElement>) => {
-    if (isPinchingRef.current) return; // pinch owns the gesture
-    if (!panStartRef.current) return;
+    if (isPinchingRef.current || !panStartRef.current) return;
     const dx = evt.clientX - panStartRef.current.clientX;
     if (!isPanningRef.current && Math.abs(dx) > PAN_THRESHOLD_PX) {
       isPanningRef.current = true;
@@ -220,7 +175,7 @@ export default function Timeline({
     if (!isPanningRef.current) return;
     const axis = axisNodeRef.current;
     if (!axis) return;
-    const rect    = axis.getBoundingClientRect();
+    const rect = axis.getBoundingClientRect();
     if (rect.width === 0) return;
     const msPerPx = panStartRef.current.spanAtStart / rect.width;
     setViewport(prev => ({ ...prev, center: panStartRef.current!.centerAtStart - dx * msPerPx }));
@@ -231,84 +186,92 @@ export default function Timeline({
     if (!isPanningRef.current && panStartRef.current) {
       const axis = axisNodeRef.current;
       if (axis) {
-        const rect     = axis.getBoundingClientRect();
+        const rect = axis.getBoundingClientRect();
         const relative = clamp((evt.clientX - rect.left) / rect.width, 0, 1);
-        const vp       = viewportRef.current;
+        const vp = viewportRef.current;
         onChange(ratioToValue(relative, viewportToRange(vp), scaleModeRef.current));
       }
     }
-    panStartRef.current  = null;
+    panStartRef.current = null;
     isPanningRef.current = false;
     setIsPanning(false);
   }, [onChange]);
 
-  // ── Ctrl+scroll zoom ──────────────────────────────────────
   useEffect(() => {
     const axis = axisNodeRef.current;
     if (!axis) return;
     const onWheel = (evt: WheelEvent) => {
       if (!evt.ctrlKey) return;
       evt.preventDefault();
-      const rect     = axis.getBoundingClientRect();
+      const rect = axis.getBoundingClientRect();
       const relative = clamp((evt.clientX - rect.left) / rect.width, 0, 1);
-      const vp       = viewportRef.current;
+      const vp = viewportRef.current;
       const anchorMs = (vp.center - vp.spanMs / 2) + relative * vp.spanMs;
       setViewport(prev => applyZoom(prev, evt.deltaY > 0 ? ZOOM_OUT : ZOOM_IN, anchorMs));
     };
     axis.addEventListener("wheel", onWheel, { passive: false });
     return () => axis.removeEventListener("wheel", onWheel);
-  }, []); // viewportRef is a stable ref — no re-registration needed
+  }, []);
 
-  // ── Zoom / reset buttons ──────────────────────────────────
-  const handleZoomIn  = useCallback(() => setViewport(p => applyZoom(p, ZOOM_IN)),  []);
+  const handleZoomIn = useCallback(() => setViewport(p => applyZoom(p, ZOOM_IN)), []);
   const handleZoomOut = useCallback(() => setViewport(p => applyZoom(p, ZOOM_OUT)), []);
-  const handleReset   = useCallback(
+  const handleReset = useCallback(
     () => setViewport({ center: (range.start + range.end) / 2, spanMs: range.end - range.start }),
     [range.start, range.end],
   );
 
-  // ── Accessibility slider ──────────────────────────────────
   const handleSliderChange = (evt: ChangeEvent<HTMLInputElement>) => {
     const ratio = Number(evt.target.value) / SLIDER_RESOLUTION;
-    const vp    = viewportRef.current;
+    const vp = viewportRef.current;
     onChange(ratioToValue(ratio, viewportToRange(vp), scaleModeRef.current));
   };
 
-  // ── Group expand / collapse ───────────────────────────────
-  const handleGroupToggle      = useCallback((id: string) => setActiveGroupId(p => p === id ? null : id), []);
-  const handleCloseSubTimeline = useCallback(() => setActiveGroupId(null), []);
-
-  // ── Hover tooltip ─────────────────────────────────────────
   const handleAxisMouseMove = useCallback((evt: ReactMouseEvent<HTMLDivElement>) => {
-    if (isPanningRef.current || panStartRef.current) { setHoverState(null); return; }
+    if (isPanningRef.current || panStartRef.current) {
+      setHoverState(null);
+      return;
+    }
     if ((evt.target as HTMLElement).closest(".timeline__event, .timeline__group")) {
       setHoverState(null);
       return;
     }
     const axis = axisNodeRef.current;
     if (!axis) return;
-    const rect     = axis.getBoundingClientRect();
+    const rect = axis.getBoundingClientRect();
     if (rect.width === 0) return;
     const relative = clamp((evt.clientX - rect.left) / rect.width, 0, 1);
-    const vp       = viewportRef.current;
+    const vp = viewportRef.current;
     setHoverState({
-      dateMs:      ratioToValue(relative, viewportToRange(vp), scaleModeRef.current),
+      dateMs: ratioToValue(relative, viewportToRange(vp), scaleModeRef.current),
       leftPercent: relative * 100,
     });
   }, []);
 
   const handleAxisMouseLeave = useCallback(() => setHoverState(null), []);
 
-  // ── Render ────────────────────────────────────────────────
+  const handleSingleSelect = useCallback((item: DetailPanelItem) => {
+    setSelectedGroupId(item.id);
+    setSelectedItems([item]);
+  }, []);
+
+  const handleGroupSelect = useCallback((id: string, items: DetailPanelItem[]) => {
+    setSelectedGroupId(prev => {
+      const next = prev === id ? null : id;
+      setSelectedItems(next === null ? [] : items);
+      return next;
+    });
+  }, []);
+
   const valueNode = renderValue?.(safeValue);
   if (viewport.spanMs <= 0) return null;
 
   return (
     <div className="timeline">
-      {/* Visually hidden — keyboard / assistive accessibility */}
       <input
         type="range"
-        min={0} max={SLIDER_RESOLUTION} step={1}
+        min={0}
+        max={SLIDER_RESOLUTION}
+        step={1}
         value={sliderValue}
         onChange={handleSliderChange}
         className="timeline__slider"
@@ -319,7 +282,7 @@ export default function Timeline({
         <div
           className={[
             "timeline__axis",
-            isPanning        ? "timeline__axis--panning"      : "",
+            isPanning ? "timeline__axis--panning" : "",
             isScaleSwitching ? "timeline__axis--transitioning" : "",
           ].filter(Boolean).join(" ")}
           ref={setAxisRef}
@@ -329,63 +292,77 @@ export default function Timeline({
           onMouseMove={handleAxisMouseMove}
           onMouseLeave={handleAxisMouseLeave}
         >
-          <div className="timeline__line" />
+          <div className="timeline__lane-ruler">
+            {autoTicks.map(tick => {
+              const left = toPercent(valueToRatio(tick.value, viewRange, scaleMode));
+              return (
+                <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
+                  <span className="timeline__tick-line" />
+                  <span className="timeline__tick-label">{tick.label}</span>
+                </div>
+              );
+            })}
+          </div>
 
-          {/* Highlight range spanned by open group */}
-          {activeGroup && (
-            <div
-              className="timeline__group-range"
-              style={{
-                left:  `${activeGroup.startRatio * 100}%`,
-                width: `${Math.max((activeGroup.endRatio - activeGroup.startRatio) * 100, 0.5)}%`,
-              }}
-              aria-hidden="true"
-            />
-          )}
-
-          {/* Year / quarter / month ticks */}
-          {autoTicks.map(tick => {
-            const left = toPercent(valueToRatio(tick.value, viewRange, scaleMode));
+          {LANE_ORDER.map((lane, idx) => {
+            const laneItems = renderItemsByLane[lane];
+            const laneTop = 30 + idx * 28;
             return (
-              <div key={tick.id} className="timeline__tick" style={{ left: `${left}%` }}>
-                <span className="timeline__tick-line" />
-                <span className="timeline__tick-label">{tick.label}</span>
+              <div
+                key={lane}
+                className="timeline__lane"
+                style={{ ["--timeline-line-top" as string]: `${laneTop}%` }}
+              >
+                <span className="timeline__lane-label">{LANE_META[lane].label}</span>
+                <div className="timeline__line" />
+
+                {laneItems.map(item => {
+                  if (item.type === "group") {
+                    const isActive = selectedGroupId === item.id;
+                    const detailItems = item.events.map(event => ({
+                      id: event.id,
+                      label: event.label,
+                      subLabel: event.subLabel,
+                      value: event.value,
+                    }));
+
+                    return (
+                      <button
+                        key={item.id}
+                        type="button"
+                        className={`timeline__group${isActive ? " timeline__group--active" : ""}`}
+                        style={{ left: `${item.leftPercent}%` }}
+                        onClick={() => handleGroupSelect(item.id, detailItems)}
+                        aria-pressed={isActive}
+                        aria-label={`${item.events.length} overlapping events`}
+                      >
+                        <span className="timeline__group-count">{item.events.length}</span>
+                      </button>
+                    );
+                  }
+
+                  return (
+                    <EventElement
+                      key={item.event.id}
+                      event={item.event}
+                      leftPercent={item.leftPercent}
+                      variant="main"
+                      range={viewRange}
+                      now={now}
+                      selected={selectedGroupId === item.event.id}
+                      onSelect={event => handleSingleSelect({
+                        id: event.id,
+                        label: event.label,
+                        subLabel: event.subLabel,
+                        value: event.value,
+                      })}
+                    />
+                  );
+                })}
               </div>
             );
           })}
 
-          {/* Events and grouped bubbles */}
-          {renderItems.map(item => {
-            if (item.type === "group") {
-              const isActive = activeGroup?.id === item.id;
-              return (
-                <button
-                  key={item.id}
-                  type="button"
-                  ref={node => setGroupNode(item.id, node)}
-                  className={`timeline__group${isActive ? " timeline__group--active" : ""}`}
-                  style={{ left: `${item.leftPercent}%` }}
-                  onClick={() => handleGroupToggle(item.id)}
-                  aria-pressed={isActive}
-                  aria-label={`${item.events.length} overlapping events`}
-                >
-                  <span className="timeline__group-count">{item.events.length}</span>
-                </button>
-              );
-            }
-            return (
-              <EventElement
-                key={item.event.id}
-                event={item.event}
-                leftPercent={item.leftPercent}
-                variant="main"
-                range={viewRange}
-                now={now}
-              />
-            );
-          })}
-
-          {/* Focus cursor (current selected value) */}
           <div
             className="timeline__focus"
             style={{ left: `${toPercent(valueRatio)}%` } as CSSProperties}
@@ -395,32 +372,18 @@ export default function Timeline({
             <span className="timeline__focus-stem" />
           </div>
 
-          {/* Hover tooltip */}
           {hoverState !== null && (
-            <div
-              className="timeline__hover-tooltip"
-              style={{ left: `${hoverState.leftPercent}%` }}
-              aria-hidden="true"
-            >
+            <div className="timeline__hover-tooltip" style={{ left: `${hoverState.leftPercent}%` }} aria-hidden="true">
               <span className="timeline__hover-line" />
               <div className="timeline__hover-card">
-                <span className="timeline__hover-date">
-                  {hoverDateFormatter.format(new Date(hoverState.dateMs))}
-                </span>
-                <span className="timeline__hover-rel">
-                  {formatHoverTiming(hoverState.dateMs, now)}
-                </span>
+                <span className="timeline__hover-date">{hoverDateFormatter.format(new Date(hoverState.dateMs))}</span>
+                <span className="timeline__hover-rel">{formatHoverTiming(hoverState.dateMs, now)}</span>
               </div>
             </div>
           )}
 
-          <TimelineControls
-            onZoomIn={handleZoomIn}
-            onZoomOut={handleZoomOut}
-            onReset={handleReset}
-          />
+          <TimelineControls onZoomIn={handleZoomIn} onZoomOut={handleZoomOut} onReset={handleReset} />
 
-          {/* Pinch-to-zoom hint — appears 3 s on first touch, then fades */}
           {showPinchHint && (
             <div className="timeline__pinch-hint" aria-live="polite" aria-atomic="true">
               Pinch to zoom
@@ -428,34 +391,14 @@ export default function Timeline({
           )}
         </div>
 
-        {/* Expandable sub-timeline for grouped events */}
         <AnimatePresence>
-          {activeGroup && axisSize.width > 0 && (
-            <SubTimeline
-              key={activeGroup.id}
-              axisWidth={axisSize.width}
-              group={activeGroup}
-              range={viewRange}
-              onClose={handleCloseSubTimeline}
-              now={now}
-              groupElement={activeGroupNode}
-            />
+          {selectedItems.length > 0 && (
+            <TimelineDetailPanel items={selectedItems} onClose={clearSelection} />
           )}
         </AnimatePresence>
       </div>
 
-      {valueNode && (
-        <div className="timeline__value timeline__value--below">{valueNode}</div>
-      )}
+      {valueNode && <div className="timeline__value timeline__value--below">{valueNode}</div>}
     </div>
   );
 }
-
-
-
-
-
-
-
-
-

--- a/src/components/timeline/TimelineDetailPanel.tsx
+++ b/src/components/timeline/TimelineDetailPanel.tsx
@@ -1,0 +1,61 @@
+import { motion } from "framer-motion";
+import { useMemo } from "react";
+import { useMediaQuery } from "../../hooks/useMediaQuery";
+import type { DetailPanelItem } from "./types";
+
+type TimelineDetailPanelProps = {
+  items: DetailPanelItem[];
+  onClose: () => void;
+};
+
+const dateFmt = new Intl.DateTimeFormat(undefined, {
+  day: "numeric",
+  month: "short",
+  year: "numeric",
+  hour: "2-digit",
+  minute: "2-digit",
+});
+
+export function TimelineDetailPanel({ items, onClose }: TimelineDetailPanelProps) {
+  const isMobile = useMediaQuery("(max-width:719px)");
+
+  const sorted = useMemo(
+    () => items.slice().sort((a, b) => a.value - b.value),
+    [items],
+  );
+
+  return (
+    <motion.aside
+      className="timeline__detail-panel"
+      role="dialog"
+      aria-label="Event details"
+      initial={isMobile ? { opacity: 0, y: "100%" } : { opacity: 0, y: 12 }}
+      animate={isMobile ? { opacity: 1, y: 0 } : { opacity: 1, y: 0 }}
+      exit={isMobile ? { opacity: 0, y: "100%" } : { opacity: 0, y: 12 }}
+      transition={{ duration: 0.22, ease: [0.32, 0.72, 0, 1] }}
+      drag={isMobile ? "y" : false}
+      dragConstraints={isMobile ? { top: 0, bottom: 240 } : undefined}
+      dragElastic={0.2}
+      onDragEnd={isMobile ? (_, info) => {
+        if (info.offset.y > 120 || info.velocity.y > 450) onClose();
+      } : undefined}
+    >
+      <header className="timeline__detail-header">
+        <h3>Selected events</h3>
+        <button type="button" className="timeline__detail-close" onClick={onClose} aria-label="Close details">
+          ✕
+        </button>
+      </header>
+
+      <ul className="timeline__detail-list">
+        {sorted.map(item => (
+          <li key={item.id} className="timeline__detail-item">
+            <span className="timeline__detail-title">{item.label}</span>
+            {item.subLabel && <span className="timeline__detail-sub">{item.subLabel}</span>}
+            <span className="timeline__detail-date">{dateFmt.format(new Date(item.value))}</span>
+          </li>
+        ))}
+      </ul>
+    </motion.aside>
+  );
+}

--- a/src/components/timeline/types.ts
+++ b/src/components/timeline/types.ts
@@ -26,12 +26,21 @@ export type TimelineEvent = {
   id: string;
   label: string;
   value: number;
+  lane?: TimelineLane;
   subLabel?: string;
   placement?: "above" | "below";
   markerShape?: MarkerShape;
   accent?: Accent;
   /** Optional direct color override for the marker dot (e.g. from event category). */
   color?: string;
+};
+
+export type TimelineLane = "personal" | "historical" | "markers";
+
+export const LANE_META: Record<TimelineLane, { label: string }> = {
+  personal:   { label: "Personal" },
+  historical: { label: "Historical" },
+  markers:    { label: "Scale markers" },
 };
 
 // ── Component props ───────────────────────────────────────────
@@ -89,6 +98,13 @@ export type SubTick = {
   label: string;
 };
 
+export type DetailPanelItem = {
+  id: string;
+  label: string;
+  subLabel?: string;
+  value: number;
+};
+
 // ── Constants ─────────────────────────────────────────────────
 
 export const SLIDER_RESOLUTION           = 5_000;
@@ -99,4 +115,3 @@ export const SUB_TIMELINE_CONNECTOR_HEIGHT = 72;
 export const SUB_TIMELINE_MARGIN_RATIO   = 0.3;
 export const MIN_SUB_TIMELINE_SPAN       = 86_400_000; // 1 day in ms
 export const PAN_THRESHOLD_PX            = 5;
-

--- a/src/context/PreferencesContext.tsx
+++ b/src/context/PreferencesContext.tsx
@@ -6,6 +6,7 @@
  */
 import { createContext, useContext, useState, type ReactNode } from "react";
 import type { EventCategory } from "../types/events";
+import type { TimelineLane } from "../components/timeline/types";
 
 export type ScaleMode = "linear" | "log";
 export type TimescalesTab = "overview" | "comparator" | "explorer";
@@ -22,6 +23,8 @@ const LS_SCALE    = "pref_scaleMode";
 const LS_CATS     = "pref_eventCategories";
 const LS_3D       = "pref_show3D";
 const LS_TS_TAB   = "pref_timescalesTab";
+const LS_LANES    = "pref_visibleTimelineLanes";
+const ALL_LANES: TimelineLane[] = ["personal", "historical", "markers"];
 
 /* ── helpers ──────────────────────────────────────────────── */
 const readLS = <T,>(key: string, fallback: T): T => {
@@ -55,6 +58,10 @@ type PreferencesCtx = {
   /* active tab in the Timescales page */
   timescalesTab: TimescalesTab;
   setTimescalesTab: (tab: TimescalesTab) => void;
+
+  /* timeline lane visibility */
+  visibleTimelineLanes: Set<TimelineLane>;
+  toggleTimelineLane: (lane: TimelineLane) => void;
 };
 
 const PreferencesCtx = createContext<PreferencesCtx | undefined>(undefined);
@@ -78,6 +85,13 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
 
   const [timescalesTab, setTimescalesTabState] = useState<TimescalesTab>(
     () => readLS<TimescalesTab>(LS_TS_TAB, "overview")
+  );
+
+  const [visibleTimelineLanes, setVisibleTimelineLanes] = useState<Set<TimelineLane>>(
+    () => {
+      const saved = readLS<TimelineLane[] | null>(LS_LANES, null);
+      return new Set<TimelineLane>(saved ?? ALL_LANES);
+    }
   );
 
   /* ── setters with persistence ───────────────────────────── */
@@ -117,6 +131,20 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
     writeLS(LS_TS_TAB, tab);
   };
 
+  const toggleTimelineLane = (lane: TimelineLane) => {
+    setVisibleTimelineLanes(prev => {
+      const next = new Set(prev);
+      if (next.has(lane)) {
+        if (next.size === 1) return prev;
+        next.delete(lane);
+      } else {
+        next.add(lane);
+      }
+      writeLS(LS_LANES, [...next]);
+      return next;
+    });
+  };
+
   return (
     <PreferencesCtx.Provider
       value={{
@@ -124,6 +152,7 @@ export function PreferencesProvider({ children }: { children: ReactNode }) {
         activeCategories, toggleCategory, resetCategories,
         show3D, setShow3D,
         timescalesTab, setTimescalesTab,
+        visibleTimelineLanes, toggleTimelineLane,
       }}
     >
       {children}
@@ -137,4 +166,3 @@ export function usePreferences(): PreferencesCtx {
   if (!ctx) throw new Error("usePreferences must be used inside PreferencesProvider");
   return ctx;
 }
-

--- a/src/css/timeline.css
+++ b/src/css/timeline.css
@@ -39,6 +39,12 @@
   gap: 10px;
 }
 
+.timeline__filter-stack {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+
 /* ── Value display ─────────────────────────────────────────── */
 .timeline__value {
   display: flex;
@@ -93,7 +99,7 @@
 /* ── Main axis ─────────────────────────────────────────────── */
 .timeline__axis {
   position: relative;
-  height: 200px;                  /* mobile base — desktop restores to 240px */
+  height: 300px;
   --timeline-line-top: 56%;
   --timeline-stripe-height: 16px;
   cursor: grab;
@@ -107,8 +113,35 @@
 }
 
 .timeline__line {
-  /* ...existing properties... */
+  position: absolute;
+  left: 0;
+  right: 0;
+  top: var(--timeline-line-top);
+  height: 2px;
+  border-radius: 999px;
+  background: linear-gradient(90deg, rgba(148, 163, 184, 0.45), rgba(129, 140, 248, 0.65), rgba(148, 163, 184, 0.45));
   z-index: var(--z-timeline-line);
+}
+
+.timeline__lane {
+  position: absolute;
+  inset: 0;
+}
+
+.timeline__lane-label {
+  position: absolute;
+  top: calc(var(--timeline-line-top) - 34px);
+  left: 10px;
+  font-size: .68rem;
+  letter-spacing: .08em;
+  text-transform: uppercase;
+  color: var(--text-muted);
+}
+
+.timeline__lane-ruler {
+  position: absolute;
+  inset: 0;
+  --timeline-line-top: 12%;
 }
 
 /* ── Group range highlight ─────────────────────────────────── */
@@ -121,7 +154,12 @@
 
 /* ── Hover tooltip ─────────────────────────────────────────── */
 .timeline__hover-tooltip {
-  /* ...existing properties... */
+  position: absolute;
+  top: 20%;
+  transform: translate(-50%, -50%);
+  display: flex;
+  flex-direction: column;
+  align-items: center;
   z-index: var(--z-hover-tooltip);
 }
 
@@ -553,6 +591,63 @@
   box-shadow: 0 18px 34px rgba(15, 23, 42, 0.5);
 }
 
+.timeline__event--selected .timeline__marker {
+  box-shadow: 0 0 0 4px rgba(165, 180, 252, 0.42), 0 18px 34px rgba(15, 23, 42, 0.5);
+}
+
+.timeline__detail-panel {
+  border-radius: 16px;
+  border: 1px solid rgba(129, 140, 248, 0.35);
+  background: rgba(10, 15, 30, 0.94);
+  box-shadow: 0 18px 36px rgba(2, 6, 23, 0.55);
+  padding: 12px;
+  backdrop-filter: blur(12px);
+}
+
+.timeline__detail-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  margin-bottom: 8px;
+}
+
+.timeline__detail-header h3 {
+  margin: 0;
+  font-size: .92rem;
+  color: var(--text-light);
+}
+
+.timeline__detail-close {
+  width: 28px;
+  height: 28px;
+  border-radius: 8px;
+  border: 1px solid rgba(129, 140, 248, 0.4);
+  background: rgba(15, 23, 42, 0.75);
+  color: var(--text-muted);
+  cursor: pointer;
+}
+
+.timeline__detail-list {
+  list-style: none;
+  margin: 0;
+  padding: 0;
+  display: grid;
+  gap: 8px;
+}
+
+.timeline__detail-item {
+  display: flex;
+  flex-direction: column;
+  gap: 2px;
+  padding: 8px 10px;
+  border-radius: 10px;
+  background: rgba(30, 41, 59, 0.45);
+}
+
+.timeline__detail-title { color: var(--text-light); font-size: .86rem; font-weight: 600; }
+.timeline__detail-sub { color: var(--text-muted); font-size: .75rem; }
+.timeline__detail-date { color: var(--indigo-100); font-size: .72rem; }
+
 /* ── Sub-timeline ──────────────────────────────────────────── */
 
 /* Mobile base: bottom-sheet fixed to the bottom of the screen (E-05) */
@@ -853,8 +948,21 @@
 /* ≥ 720px — desktop: full axis height, show scroll hint */
 @media (min-width: 720px) {
   .timeline-card                    { margin-top: 24px; }
-  .timeline__axis                   { height: 240px; }
+  .timeline__axis                   { height: 330px; }
   .timeline__label                  { max-width: 240px; }
   .timeline__value-primary          { font-size: var(--text-2xl); }
   .timeline__ctrl-scroll-hint       { display: inline; }
+}
+
+@media (max-width: 719px) {
+  .timeline__detail-panel {
+    position: fixed;
+    left: 0;
+    right: 0;
+    bottom: 0;
+    max-height: 56vh;
+    overflow: auto;
+    z-index: var(--z-subtimeline-mob);
+    border-radius: 18px 18px 0 0;
+  }
 }

--- a/src/pages/Milestones.tsx
+++ b/src/pages/Milestones.tsx
@@ -14,6 +14,7 @@ import { CATEGORY_META, type EventCategory } from "../types/events";
 import { Timeline3DWrapper } from "../components/3d/Timeline3DWrapper";
 import { WEB_GL_SUPPORTED } from "../utils/webgl";
 import { useMediaQuery } from "../hooks/useMediaQuery";
+import { LANE_META, type TimelineLane } from "../components/timeline/types";
 
 const FUTURE_WINDOW_YEARS = 40;
 const LOOKBACK_YEARS = 20;
@@ -65,12 +66,12 @@ const buildTimelineData = (birthDate: Date, birthTime: string): TimelineData | n
   const billionSeconds = base.add(1_000_000_000, "second");
 
   const events: TimelineEvent[] = [
-    { id: "birth", label: "Birth", subLabel: formatWithWeekday(base), value: base.valueOf(), placement: "above", accent: "highlight" },
-    { id: "midpoint", label: "Midpoint", subLabel: formatWithWeekday(midpoint), value: midpoint.valueOf(), placement: "above", accent: "muted" },
-    { id: "today", label: "Today", subLabel: formatWithWeekday(now), value: now.valueOf(), placement: "below", markerShape: "triangle", accent: "highlight" },
-    { id: "10kdays", label: "10,000 days old", subLabel: formatWithWeekday(tenThousandDays), value: tenThousandDays.valueOf(), placement: "below" },
-    { id: "1Bseconds", label: "1 billion seconds old", subLabel: formatWithWeekday(billionSeconds, true), value: billionSeconds.valueOf(), placement: "above" },
-    { id: "500months", label: "500 months old", subLabel: formatWithWeekday(fiveHundredMonth, true), value: fiveHundredMonth.valueOf(), placement: "above" },
+    { id: "birth", label: "Birth", subLabel: formatWithWeekday(base), value: base.valueOf(), placement: "above", accent: "highlight", lane: "personal" },
+    { id: "midpoint", label: "Midpoint", subLabel: formatWithWeekday(midpoint), value: midpoint.valueOf(), placement: "above", accent: "muted", lane: "personal" },
+    { id: "today", label: "Today", subLabel: formatWithWeekday(now), value: now.valueOf(), placement: "below", markerShape: "triangle", accent: "highlight", lane: "personal" },
+    { id: "10kdays", label: "10,000 days old", subLabel: formatWithWeekday(tenThousandDays), value: tenThousandDays.valueOf(), placement: "below", lane: "markers" },
+    { id: "1Bseconds", label: "1 billion seconds old", subLabel: formatWithWeekday(billionSeconds, true), value: billionSeconds.valueOf(), placement: "above", lane: "markers" },
+    { id: "500months", label: "500 months old", subLabel: formatWithWeekday(fiveHundredMonth, true), value: fiveHundredMonth.valueOf(), placement: "above", lane: "markers" },
   ];
 
   return {
@@ -98,7 +99,14 @@ export default function Milestones() {
   const [tab, setTab] = useState<keyof typeof TAB_ROWS>("Classic");
   const [focusValue, setFocusValue] = useState(() => dayjs().valueOf());
   const { events: historicalEvents } = useHistoricalEvents();
-  const { activeCategories, toggleCategory, show3D, setShow3D } = usePreferences();
+  const {
+    activeCategories,
+    toggleCategory,
+    show3D,
+    setShow3D,
+    visibleTimelineLanes,
+    toggleTimelineLane,
+  } = usePreferences();
   /** Perspectives panel: always open on desktop, toggle on mobile */
   const isDesktop = useMediaQuery("(min-width:720px)");
   const [perspMobileOpen, setPerspMobileOpen] = useState(false);
@@ -145,12 +153,14 @@ export default function Milestones() {
         placement: e.placement ?? "above",
         accent: "muted" as const,
         color: CATEGORY_META[e.category].color,
+        lane: "historical" as const,
       }));
-
-    return [...personal, ...historical];
-  }, [timeline, historicalEvents, activeCategories]);
+    const merged = [...personal, ...historical];
+    return merged.filter(event => visibleTimelineLanes.has(event.lane ?? "personal"));
+  }, [timeline, historicalEvents, activeCategories, visibleTimelineLanes]);
 
   const CATEGORIES = Object.keys(CATEGORY_META) as EventCategory[];
+  const LANE_KEYS = Object.keys(LANE_META) as TimelineLane[];
 
   const renderFocus = useCallback((value: number) => {
     const instant = dayjs(value);
@@ -296,30 +306,52 @@ export default function Milestones() {
 
             {/* ── Historical event category filters (only in 2D mode) ── */}
             {!show3D && (
-              <div className="timeline__filter-section">
-                <span className="timeline__filter-section__label">Filter events</span>
-                <div className="timeline__category-filters" role="group" aria-label="Event categories">
-                  {CATEGORIES.map(cat => {
-                    const meta   = CATEGORY_META[cat];
-                    const active = activeCategories.has(cat);
-                    return (
-                      <button
-                        key={cat}
-                        type="button"
-                        className={`timeline__category-filter${active ? " timeline__category-filter--active" : ""}`}
-                        onClick={() => toggleCategory(cat)}
-                        aria-pressed={active}
-                        style={active ? { background: `${meta.color}33`, borderColor: meta.color } : undefined}
-                      >
-                        <span
-                          className="timeline__category-filter__dot"
-                          style={{ background: meta.color }}
-                          aria-hidden="true"
-                        />
-                        {meta.label}
-                      </button>
-                    );
-                  })}
+              <div className="timeline__filter-stack">
+                <div className="timeline__filter-section">
+                  <span className="timeline__filter-section__label">Filter events</span>
+                  <div className="timeline__category-filters" role="group" aria-label="Event categories">
+                    {CATEGORIES.map(cat => {
+                      const meta = CATEGORY_META[cat];
+                      const active = activeCategories.has(cat);
+                      return (
+                        <button
+                          key={cat}
+                          type="button"
+                          className={`timeline__category-filter${active ? " timeline__category-filter--active" : ""}`}
+                          onClick={() => toggleCategory(cat)}
+                          aria-pressed={active}
+                          style={active ? { background: `${meta.color}33`, borderColor: meta.color } : undefined}
+                        >
+                          <span
+                            className="timeline__category-filter__dot"
+                            style={{ background: meta.color }}
+                            aria-hidden="true"
+                          />
+                          {meta.label}
+                        </button>
+                      );
+                    })}
+                  </div>
+                </div>
+
+                <div className="timeline__filter-section">
+                  <span className="timeline__filter-section__label">Visible lanes</span>
+                  <div className="timeline__category-filters" role="group" aria-label="Timeline lanes">
+                    {LANE_KEYS.map(lane => {
+                      const active = visibleTimelineLanes.has(lane);
+                      return (
+                        <button
+                          key={lane}
+                          type="button"
+                          className={`timeline__category-filter${active ? " timeline__category-filter--active" : ""}`}
+                          onClick={() => toggleTimelineLane(lane)}
+                          aria-pressed={active}
+                        >
+                          {LANE_META[lane].label}
+                        </button>
+                      );
+                    })}
+                  </div>
                 </div>
               </div>
             )}


### PR DESCRIPTION
### Motivation

- Reduce event clustering and improve timeline readability by evolving the single-line timeline into a lane-based Time Map with a shared viewport/scale model.
- Replace the confusing expandable sub-timeline with a clearer detail panel UX that works well on desktop and mobile (half-sheet + drag-to-dismiss).
- Provide users controls to toggle which lanes are visible and persist those preferences.

### Description

- Introduced lane support on events by adding `lane?: TimelineLane` and `LANE_META`, and built per-lane render pipelines in `src/components/timeline/Timeline.tsx` that reuse `buildRenderItems` lane-by-lane (lanes: `personal`, `historical`, `markers`).
- Replaced the old `SubTimeline` expansion with a new `TimelineDetailPanel` component (`src/components/timeline/TimelineDetailPanel.tsx`) that shows either a single event or the list of grouped events; the panel is anchored on desktop and a draggable half-sheet on mobile (Framer Motion).
- Extended `EventElement` with selection/click/keyboard handlers and a visual `selected` state to support the detail panel interaction (`src/components/timeline/EventElement.tsx`).
- Added persistent lane visibility controls to preferences by extending `PreferencesContext` with `visibleTimelineLanes` and `toggleTimelineLane` (localStorage key `pref_visibleTimelineLanes`) and surfaced the UI in `Milestones.tsx` (Visible lanes chips) to filter timeline events by lane.
- Updated `Milestones.tsx` to tag personal/historical/marker events with lanes and to filter `allEvents` by `visibleTimelineLanes` before passing to the timeline.
- Adjusted timeline CSS (`src/css/timeline.css`) for lane layout, ruler placement, detail panel styles and increased axis height for readability.
- Documented the completion of Phase 5 and recorded decisions D-06 / D-07 / D-08 in `refactor_docs/refactor_3/PLAN.md` and `refactor_docs/refactor_3/DECISIONS.md`.

### Testing

- Ran `npm run lint` which completed successfully with three preexisting non-blocking `react-refresh/only-export-components` warnings (not caused by this change).
- Ran unit tests with `npm test -- --run`; build-level tests pass but `vitest` shows 2 failing assertions in `src/tests/format.test.ts` related to locale-format expectations (these failures are pre-existing/localization expectations and were not introduced by this PR).
- Ran `npm run build` which completed successfully and produced a working production bundle.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69e68c838f84832faed3e526798decf6)